### PR TITLE
Add python_requires >=3.8 to setup.py and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The official Python adapter for [Buildkite Test Analytics](https://buildkite.com/test-analytics) which collects information about your tests.
 
+**Supported python versions:** >=3.8
+
 ⚒ **Supported test frameworks:** pytest.
 
 📦 **Supported CI systems:** Buildkite, GitHub Actions, CircleCI, and others via the `BUILDKITE_ANALYTICS_*` environment variables.

--- a/setup.py
+++ b/setup.py
@@ -32,4 +32,5 @@ setup(name='buildkite-test-collector',
       },
       entry_points={
           "pytest11": ["buildkite-test-collector = buildkite_test_collector.pytest_plugin"]
-      })
+      },
+      python_requires=">=3.8")


### PR DESCRIPTION
Addressing the github issue raised here: https://github.com/buildkite/test-collector-python/issues/5
Explicitly documenting the python versions supported are >=3.8  and setting `python_requires=">=3.8"` in `setup.py`