### PR TITLE
Gracefully handle return characters in api token

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='buildkite-test-collector',
-      version='0.1.3',
+      version='0.1.4',
       description='Buildkite Test Analytics collector',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/src/buildkite_test_collector/collector/api.py
+++ b/src/buildkite_test_collector/collector/api.py
@@ -4,6 +4,7 @@ from typing import Optional
 from os import environ
 from sys import stderr
 from requests import post, Response
+from requests.exceptions import InvalidHeader
 from .payload import Payload
 
 
@@ -17,15 +18,19 @@ def submit(payload: Payload, batch_size=100) -> Optional[Response]:
         print("Warning: No `BUILDKITE_ANALYTICS_TOKEN` environment variable present", file=stderr)
 
     if token:
-        for payload_slice in payload.into_batches(batch_size):
-            response = post("https://analytics-api.buildkite.com/v1/uploads",
-                            json=payload_slice.as_json(),
-                            headers={
-                                "Content-Type": "application/json",
-                                "Authorization": f"Token token=\"{token}\""
-                            },
-                            timeout=30)
-            if response.status_code >= 300:
-                return response
+        try:
+            for payload_slice in payload.into_batches(batch_size):
+                response = post("https://analytics-api.buildkite.com/v1/uploads",
+                                json=payload_slice.as_json(),
+                                headers={
+                                    "Content-Type": "application/json",
+                                    "Authorization": f"Token token=\"{token}\""
+                                },
+                                timeout=30)
+                if response.status_code >= 300:
+                    return response
+        except InvalidHeader as error:
+            print("Warning: Invalid `BUILDKITE_ANALYTICS_TOKEN` environment variable", file=stderr)
+            print(error, file=stderr)
 
     return response

--- a/tests/buildkite_test_collector/collector/test_api.py
+++ b/tests/buildkite_test_collector/collector/test_api.py
@@ -16,6 +16,13 @@ def test_submit_with_missing_api_key_environment_variable_returns_none():
         assert submit(payload) is None
 
 
+def test_submit_with_invalid_api_key_environment_variable_returns_none():
+    with mock.patch.dict(os.environ, {"CI": "true", "BUILDKITE_ANALYTICS_TOKEN": "\n"}):
+        payload = Payload.init(detect_env())
+
+        assert submit(payload) is None
+
+
 @responses.activate
 def test_submit_with_payload_returns_an_api_response(successful_test):
     responses.add(


### PR DESCRIPTION
It's important that the collector doesn't break customer builds. If the buildkite api token includes a return character (i.e., \r or \n) the Python libraries throw an InvalidHeader exception, which would cause the process to error out. This patch gracefully handles the error so the customer's test suite doesn't fail.