### PR TITLE
Add Collector name and version to Analytics API payload

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
 from setuptools import setup, find_packages
+from src.buildkite_test_collector.collector import constants
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-setup(name='buildkite-test-collector',
-      version='0.1.4',
+setup(name=constants.COLLECTOR_NAME,
+      version=constants.VERSION,
       description='Buildkite Test Analytics collector',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/src/buildkite_test_collector/collector/constants.py
+++ b/src/buildkite_test_collector/collector/constants.py
@@ -1,0 +1,6 @@
+# constants.py
+
+"""This module defines collector-level constants."""
+
+COLLECTOR_NAME='buildkite-test-collector'
+VERSION='0.1.4'

--- a/src/buildkite_test_collector/collector/run_env.py
+++ b/src/buildkite_test_collector/collector/run_env.py
@@ -3,8 +3,8 @@
 from dataclasses import dataclass
 from typing import Dict, Optional
 from uuid import uuid4
-
 import os
+from .constants import COLLECTOR_NAME, VERSION # pylint: disable=W0611
 
 # pylint: disable=C0103 disable=R0902
 
@@ -115,7 +115,9 @@ class RuntimeEnvironment:
             "branch": self.branch,
             "commit_sha": self.commit_sha,
             "message": self.message,
-            "url": self.url
+            "url": self.url,
+            "collector": 'python-{COLLECTOR_NAME}',
+            "version": VERSION
         }
 
         return {k: v for k, v in attrs.items() if v is not None}

--- a/tests/buildkite_test_collector/collector/test_run_env.py
+++ b/tests/buildkite_test_collector/collector/test_run_env.py
@@ -3,6 +3,7 @@ from uuid import uuid4, UUID
 import os
 import mock
 
+from buildkite_test_collector.collector.constants import COLLECTOR_NAME, VERSION # pylint: disable=W0611
 from buildkite_test_collector.collector.run_env import detect_env
 
 
@@ -67,7 +68,6 @@ def test_detect_env_with_github_actions_env_vars_returns_the_correct_environment
         assert runtime_env.job_id is None
         assert runtime_env.message is None
 
-
 def test_detect_env_with_circle_ci_env_vars_returns_the_correct_environment():
     build_num = str(randint(0, 1000))
     workflow_id = str(uuid4())
@@ -93,7 +93,6 @@ def test_detect_env_with_circle_ci_env_vars_returns_the_correct_environment():
         assert runtime_env.job_id is None
         assert runtime_env.message is None
 
-
 def test_detect_env_with_generic_env_vars():
     env = {
         "CI": "true"
@@ -111,7 +110,6 @@ def test_detect_env_with_generic_env_vars():
         assert runtime_env.job_id is None
         assert runtime_env.message is None
 
-
 def test_env_as_json(fake_env):
     json = fake_env.as_json()
 
@@ -123,3 +121,5 @@ def test_env_as_json(fake_env):
     assert json["commit_sha"] == fake_env.commit_sha
     assert json["message"] == fake_env.message
     assert json["url"] == fake_env.url
+    assert json["collector"] == 'python-{COLLECTOR_NAME}'
+    assert json["version"] == VERSION


### PR DESCRIPTION
TA is working on displaying a tally of the types of collectors our customers are using. We can gather this data via the collector names and versions, however some collectors are missing this data (please see related linear ticket for list).

As I am unfamilar with python, I moved the NAME and VERSION values from the `setup.py` and defined them in a new file `constants.py`. This way we can share these values across file names while keeping them consistent. Happy to change if a Python speaker knows better!

This PR does not include the necessary version bump + publish to Python Package Index.

This collector will now emit the collector name "**python-buildkite-test-collector**"

-----
[Linear Ticket](https://linear.app/buildkite/issue/PIE-1353/add-collector-name-and-version-to-python-test-collector)
[Related Linear Ticket](https://linear.app/buildkite/issue/PIE-435/store-collector-type-junit-rspec-etc)