### PR TITLE
PIE-435: Fix Collector String interpolation

### DIFF
--- a/src/buildkite_test_collector/collector/run_env.py
+++ b/src/buildkite_test_collector/collector/run_env.py
@@ -116,7 +116,7 @@ class RuntimeEnvironment:
             "commit_sha": self.commit_sha,
             "message": self.message,
             "url": self.url,
-            "collector": 'python-{COLLECTOR_NAME}',
+            "collector": f"python-{COLLECTOR_NAME}",
             "version": VERSION
         }
 

--- a/tests/buildkite_test_collector/collector/test_run_env.py
+++ b/tests/buildkite_test_collector/collector/test_run_env.py
@@ -121,5 +121,5 @@ def test_env_as_json(fake_env):
     assert json["commit_sha"] == fake_env.commit_sha
     assert json["message"] == fake_env.message
     assert json["url"] == fake_env.url
-    assert json["collector"] == 'python-{COLLECTOR_NAME}'
+    assert json["collector"] == 'python-buildkite-test-collector'
     assert json["version"] == VERSION


### PR DESCRIPTION
```
{"buildkite-test_collector"=>79,
 "js-buildkite-test-collector"=>58,
 "test-collector-buildkite-plugin"=>52,
 "rspec-buildkite"=>5,
 nil=>94,
 "python-{COLLECTOR_NAME}"=>4, <----- 💥 rage 💥
 "test-collector-swift"=>2,
 "js-integration"=>1}
```

Discovered that string interpolation involves a 'f' special key and double quotes in python.