### PR TITLE
[PIE-1486] python collector shouldn't fail customer builds

### DIFF
--- a/src/buildkite_test_collector/collector/api.py
+++ b/src/buildkite_test_collector/collector/api.py
@@ -6,6 +6,7 @@ from sys import stderr
 from requests import post, Response
 from requests.exceptions import InvalidHeader
 from .payload import Payload
+import traceback
 
 
 def submit(payload: Payload, batch_size=100) -> Optional[Response]:
@@ -32,5 +33,8 @@ def submit(payload: Payload, batch_size=100) -> Optional[Response]:
         except InvalidHeader as error:
             print("Warning: Invalid `BUILDKITE_ANALYTICS_TOKEN` environment variable", file=stderr)
             print(error, file=stderr)
+        except Exception:
+            error_message = traceback.format_exc()
+            print(error_message, file=stderr)
 
     return response

--- a/src/buildkite_test_collector/collector/api.py
+++ b/src/buildkite_test_collector/collector/api.py
@@ -3,10 +3,10 @@
 from typing import Optional
 from os import environ
 from sys import stderr
+import traceback
 from requests import post, Response
 from requests.exceptions import InvalidHeader
 from .payload import Payload
-import traceback
 
 
 def submit(payload: Payload, batch_size=100) -> Optional[Response]:
@@ -33,7 +33,7 @@ def submit(payload: Payload, batch_size=100) -> Optional[Response]:
         except InvalidHeader as error:
             print("Warning: Invalid `BUILDKITE_ANALYTICS_TOKEN` environment variable", file=stderr)
             print(error, file=stderr)
-        except Exception:
+        except Exception: # pylint: disable=broad-except
             error_message = traceback.format_exc()
             print(error_message, file=stderr)
 

--- a/src/buildkite_test_collector/collector/api.py
+++ b/src/buildkite_test_collector/collector/api.py
@@ -26,7 +26,7 @@ def submit(payload: Payload, batch_size=100) -> Optional[Response]:
                                     "Content-Type": "application/json",
                                     "Authorization": f"Token token=\"{token}\""
                                 },
-                                timeout=30)
+                                timeout=60)
                 if response.status_code >= 300:
                     return response
         except InvalidHeader as error:

--- a/tests/buildkite_test_collector/collector/test_api.py
+++ b/tests/buildkite_test_collector/collector/test_api.py
@@ -3,6 +3,8 @@ from uuid import uuid4
 import os
 import mock
 import responses
+import pytest
+import sys
 
 from buildkite_test_collector.collector.run_env import detect_env
 from buildkite_test_collector.collector.api import submit
@@ -24,6 +26,7 @@ def test_submit_with_invalid_api_key_environment_variable_returns_none():
         assert submit(payload) is None
 
 @responses.activate
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")
 def test_submit_with_payload_timeout_captures_ConnectTimeout_error(capfd, successful_test):
     responses.add(
         responses.POST,
@@ -43,6 +46,7 @@ def test_submit_with_payload_timeout_captures_ConnectTimeout_error(capfd, succes
         assert "ConnectTimeout" in captured.err
 
 @responses.activate
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")
 def test_submit_with_payload_timeout_captures_ReadTimeout_error(capfd, successful_test):
     responses.add(
         responses.POST,


### PR DESCRIPTION
Linear ticket: [https://linear.app/buildkite/issue/PIE-1486/python-collector-shouldnt-fail-customer-builds](https://linear.app/buildkite/issue/PIE-1486/python-collector-shouldnt-fail-customer-builds)

There was an incident affecting the main database, and as a result TA was timing out. The TA timeouts then caused a customer's builds to break which is bad.

Changes:
- introduced catch all for exceptions in `submit` so we don't fail builds if there is a `ReadTimeout` or a `ConnectTimeout`
- added specs to cover those two exceptions

Future plans:
- will probably add retries for `ReadTimeout` and `ConnectTimeout`