### PR TITLE
PIE-1480 Remove identifier from Python test collector payloads

### DIFF
--- a/src/buildkite_test_collector/collector/payload.py
+++ b/src/buildkite_test_collector/collector/payload.py
@@ -110,7 +110,6 @@ class TestData:
     id: UUID
     scope: str
     name: str
-    identifier: str
     history: TestHistory
     location: Optional[str] = None
     result: Union[TestResultPassed, TestResultFailed,
@@ -120,14 +119,12 @@ class TestData:
     def start(cls, id: UUID,
               scope: str,
               name: str,
-              identifier: str,
               location: Optional[str] = None) -> 'TestData':
         """Build a new instance with it's start_at time set to now"""
         return cls(
             id=id,
             scope=scope,
             name=name,
-            identifier=identifier,
             location=location,
             history=TestHistory(start_at=Instant.now())
         )
@@ -169,7 +166,6 @@ class TestData:
             "id": str(self.id),
             "scope": self.scope,
             "name": self.name,
-            "identifier": self.identifier,
             "location": self.location,
             "history": self.history.as_json(started_at)
         }

--- a/src/buildkite_test_collector/pytest_plugin/buildkite_plugin.py
+++ b/src/buildkite_test_collector/pytest_plugin/buildkite_plugin.py
@@ -23,7 +23,7 @@ class BuildkitePlugin:
         name = chunks[-1]
         location = f"{location[0]}:{location[1]}"
 
-        test_data = TestData.start(uuid4(), scope, name, nodeid, location)
+        test_data = TestData.start(uuid4(), scope, name, location)
         self.in_flight[nodeid] = test_data
 
     def pytest_runtest_logreport(self, report):

--- a/tests/buildkite_test_collector/collector/test_payload.py
+++ b/tests/buildkite_test_collector/collector/test_payload.py
@@ -102,7 +102,6 @@ def test_test_data_start(successful_test):
     test_data = TestData.start(id=successful_test.id,
                                scope=successful_test.scope,
                                name=successful_test.name,
-                               identifier=successful_test.identifier,
                                location=successful_test.location)
 
     assert test_data.history.start_at.seconds == pytest.approx(
@@ -147,7 +146,6 @@ def test_test_data_as_json(incomplete_test):
     assert json["id"] == str(incomplete_test.id)
     assert json["scope"] == incomplete_test.scope
     assert json["name"] == incomplete_test.name
-    assert json["identifier"] == incomplete_test.identifier
     assert json["location"] == incomplete_test.location
     assert json["history"] == incomplete_test.history.as_json(now)
 

--- a/tests/buildkite_test_collector/conftest.py
+++ b/tests/buildkite_test_collector/conftest.py
@@ -17,7 +17,6 @@ def successful_test(history_finished) -> TestData:
         id=uuid4(),
         scope="wyld stallyns",
         name="san dimas meltdown",
-        identifier="wyld stallyns :: san dimas meltdown",
         location="san_dimas_meltdown.py:1",
         result=TestResultPassed(),
         history=history_finished
@@ -40,7 +39,6 @@ def incomplete_test(history_started) -> TestData:
         id=uuid4(),
         scope="wyld stallyns",
         name="san dimas meltdown",
-        identifier="wyld stallyns :: san dimas meltdown",
         location="san_dimas_meltdown.py:1",
         result=None,
         history=history_started


### PR DESCRIPTION
**Description**
We have removed identifier field from DB test table, and we no longer using it in TA.
This PR is for removing identifier from this collector so that they stop sending identifier to TA. [We'll not make a release for this PR](https://linear.app/buildkite/issue/PIE-1427#comment-9ea47561)

**Context**
Ticket: https://linear.app/buildkite/issue/PIE-1480/remove-identifier-from-python-test-collector-payloads
Parent ticket: https://linear.app/buildkite/issue/PIE-1427/remove-identifier-from-test-collector-payloads

**Changes**
Remove identifier from payload
Update tests


