### PR TITLE
Add conda installation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ The official Python adapter for [Buildkite Test Analytics](https://buildkite.com
             ]
         }
 ```
+or install via `conda`
+
+```shell
+conda install -c conda-forge buildkite-test-collector
+```
 
 3. Set up your API token
 


### PR DESCRIPTION
This extens the installation instructions to also include `conda` since `buildkite-test-collector` is now available on `conda-forge` ([feedstock](https://github.com/conda-forge/buildkite-test-collector-feedstock), [package](https://anaconda.org/conda-forge/buildkite-test-collector))

Entirely optional, feel free to close in case you'd only want to officially support PyPi