### PR TITLE
Silence warning unless debug is present

### DIFF
--- a/src/buildkite_test_collector/pytest_plugin/__init__.py
+++ b/src/buildkite_test_collector/pytest_plugin/__init__.py
@@ -1,6 +1,7 @@
 """Buildkite test collector for Pytest."""
 
 from logging import warning
+from os import environ
 
 import pytest
 
@@ -24,12 +25,13 @@ def spans(request):
 def pytest_configure(config):
     """pytest_configure hook callback"""
     env = detect_env()
+    debug = environ.get("BUILDKITE_ANALYTICS_DEBUG_ENABLED")
 
     if env:
         plugin = BuildkitePlugin(Payload.init(env))
         setattr(config, '_buildkite', plugin)
         config.pluginmanager.register(plugin)
-    else:
+    elif debug:
         warning("Unable to detect CI environment.  No test analytics will be sent.")
 
 


### PR DESCRIPTION
Similar to https://github.com/buildkite/test-collector-python/issues/7 it would be great for the plugin to honour the `BUILDKITE_ANALYTICS_DEBUG_ENABLED` env variable and be less verbose by default.