### PR TITLE
Check we're not in an xdist worker before submitting payload

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
 
     env:
       BUILDKITE_ANALYTICS_TOKEN: ${{ secrets.BUILDKITE_ANALYTICS_TOKEN }}
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/src/buildkite_test_collector/pytest_plugin/__init__.py
+++ b/src/buildkite_test_collector/pytest_plugin/__init__.py
@@ -39,7 +39,7 @@ def pytest_configure(config):
 def pytest_unconfigure(config):
     """pytest_unconfigure hook callback"""
     plugin = getattr(config, '_buildkite', None)
-    if plugin:
+    if plugin and not hasattr(config, "workerinput"):
         submit(plugin.payload)
         del config._buildkite
         config.pluginmanager.unregister(plugin)

--- a/src/buildkite_test_collector/pytest_plugin/__init__.py
+++ b/src/buildkite_test_collector/pytest_plugin/__init__.py
@@ -1,3 +1,4 @@
+# pylint: disable=line-too-long
 """Buildkite test collector for Pytest."""
 
 from logging import warning
@@ -39,7 +40,13 @@ def pytest_configure(config):
 def pytest_unconfigure(config):
     """pytest_unconfigure hook callback"""
     plugin = getattr(config, '_buildkite', None)
-    if plugin and not hasattr(config, "workerinput"):
-        submit(plugin.payload)
+
+    if plugin:
+        # Only submit if this is not an xdist worker,
+        # this prevents duplicate payload submissions
+        # see https://github.com/pytest-dev/pytest-xdist/blob/fabdbe3fd2dbaf0e2764697ba4c79938d565dc44/src/xdist/plugin.py#L305
+        if not hasattr(config, "workerinput"):
+            submit(plugin.payload)
+
         del config._buildkite
         config.pluginmanager.unregister(plugin)


### PR DESCRIPTION
The way xdist works is somewhat surprising:

- one might expect a single pytest execution, however all workers run the full pytest lifecycle as well as the main controller process resulting in `n+1` pytest executions (where `n` is the actual number of workers)
- the workers also swallow stdout so introspecting this was producing misleading results when trying to reproduce locally (see this thread for more info https://github.com/pytest-dev/pytest-xdist/issues/354)

This checks that we're in the controller process (eg the existence of "workerinput" implies an xdist worker thread), and only submits the results payload if we're in the controller or `master` process.

The JUnit test reporter has a range of other strategies to deal with xdist but this particular check inspired this fix https://github.com/pytest-dev/pytest/blob/ac4189875562a6ce5b502c3dd87156c0367cf8f1/src/_pytest/junitxml.py#L429