### PR TITLE
Add TEST_ANALYTICS_COMMIT_MESSAGE

### DIFF
--- a/src/buildkite_test_collector/collector/run_env.py
+++ b/src/buildkite_test_collector/collector/run_env.py
@@ -54,7 +54,7 @@ def __github_actions_env() -> Optional['RuntimeEnvironment']:
         commit_sha=__get_env("GITHUB_SHA"),
         number=run_number,
         job_id=None,
-        message=None
+        message=__get_env("TEST_ANALYTICS_COMMIT_MESSAGE")
     )
 
 
@@ -73,7 +73,7 @@ def __circle_ci_env() -> Optional['RuntimeEnvironment']:
         commit_sha=__get_env("CIRCLE_SHA1"),
         number=build_num,
         job_id=None,
-        message=None
+        message=__get_env("TEST_ANALYTICS_COMMIT_MESSAGE")
     )
 
 

--- a/src/buildkite_test_collector/collector/run_env.py
+++ b/src/buildkite_test_collector/collector/run_env.py
@@ -54,7 +54,7 @@ def __github_actions_env() -> Optional['RuntimeEnvironment']:
         commit_sha=__get_env("GITHUB_SHA"),
         number=run_number,
         job_id=None,
-        message=__get_env("TEST_ANALYTICS_COMMIT_MESSAGE")
+        message=__get_env("TEST_ANALYTICS_COMMIT_MESSAGE"),
     )
 
 
@@ -73,7 +73,7 @@ def __circle_ci_env() -> Optional['RuntimeEnvironment']:
         commit_sha=__get_env("CIRCLE_SHA1"),
         number=build_num,
         job_id=None,
-        message=__get_env("TEST_ANALYTICS_COMMIT_MESSAGE")
+        message=__get_env("TEST_ANALYTICS_COMMIT_MESSAGE"),
     )
 
 

--- a/tests/buildkite_test_collector/collector/test_run_env.py
+++ b/tests/buildkite_test_collector/collector/test_run_env.py
@@ -93,7 +93,7 @@ def test_detect_env_with_circle_ci_env_vars_returns_the_correct_environment():
         assert runtime_env.commit_sha == commit
         assert runtime_env.number == build_num
         assert runtime_env.job_id is None
-        assert runtime_env.message is None
+        assert runtime_env.message is "excellent adventure"
 
 def test_detect_env_with_generic_env_vars():
     env = {

--- a/tests/buildkite_test_collector/collector/test_run_env.py
+++ b/tests/buildkite_test_collector/collector/test_run_env.py
@@ -67,7 +67,7 @@ def test_detect_env_with_github_actions_env_vars_returns_the_correct_environment
         assert runtime_env.commit_sha == commit
         assert runtime_env.number == run_number
         assert runtime_env.job_id is None
-        assert runtime_env.message is "excellent adventure"
+        assert runtime_env.message == "excellent adventure"
 
 def test_detect_env_with_circle_ci_env_vars_returns_the_correct_environment():
     build_num = str(randint(0, 1000))
@@ -93,7 +93,7 @@ def test_detect_env_with_circle_ci_env_vars_returns_the_correct_environment():
         assert runtime_env.commit_sha == commit
         assert runtime_env.number == build_num
         assert runtime_env.job_id is None
-        assert runtime_env.message is "excellent adventure"
+        assert runtime_env.message == "excellent adventure"
 
 def test_detect_env_with_generic_env_vars():
     env = {

--- a/tests/buildkite_test_collector/collector/test_run_env.py
+++ b/tests/buildkite_test_collector/collector/test_run_env.py
@@ -54,6 +54,7 @@ def test_detect_env_with_github_actions_env_vars_returns_the_correct_environment
         "GITHUB_RUN_ID": run_id,
         "GITHUB_REF": "rufus",
         "GITHUB_SHA": commit,
+        "TEST_ANALYTICS_COMMIT_MESSAGE": "excellent adventure"
     }
 
     with mock.patch.dict(os.environ, env, clear=True):
@@ -66,7 +67,7 @@ def test_detect_env_with_github_actions_env_vars_returns_the_correct_environment
         assert runtime_env.commit_sha == commit
         assert runtime_env.number == run_number
         assert runtime_env.job_id is None
-        assert runtime_env.message is None
+        assert runtime_env.message is "excellent adventure"
 
 def test_detect_env_with_circle_ci_env_vars_returns_the_correct_environment():
     build_num = str(randint(0, 1000))
@@ -78,7 +79,8 @@ def test_detect_env_with_circle_ci_env_vars_returns_the_correct_environment():
         "CIRCLE_WORKFLOW_ID": workflow_id,
         "CIRCLE_BUILD_URL": "https://example.test/circle",
         "CIRCLE_BRANCH": "rufus",
-        "CIRCLE_SHA1": commit
+        "CIRCLE_SHA1": commit,
+        "TEST_ANALYTICS_COMMIT_MESSAGE": "excellent adventure"
     }
 
     with mock.patch.dict(os.environ, env, clear=True):


### PR DESCRIPTION
Fixes: #31.

(I chose `TEST_ANALYTICS_` prefix because I didn't want to confuse users of GHA or Circle into thinking that the env-var was a native-to-their-platform one then not find it within docs)