### PR TITLE
v0.1.9

### DIFF
--- a/src/buildkite_test_collector/collector/constants.py
+++ b/src/buildkite_test_collector/collector/constants.py
@@ -3,4 +3,4 @@
 """This module defines collector-level constants."""
 
 COLLECTOR_NAME='buildkite-test-collector'
-VERSION='0.1.8'
+VERSION='0.1.9'


### PR DESCRIPTION
We published v0.1.9 of the Python collector but didn't update the
main branch with the verison bump.
