### PR TITLE
Add `--json` option to save collector payload to JSON

### DIFF
--- a/src/buildkite_test_collector/pytest_plugin/__init__.py
+++ b/src/buildkite_test_collector/pytest_plugin/__init__.py
@@ -48,5 +48,21 @@ def pytest_unconfigure(config):
         if not hasattr(config, "workerinput"):
             submit(plugin.payload)
 
+        jsonpath = config.option.jsonpath
+        if jsonpath:
+            plugin.save_payload_as_json(jsonpath)
+
         del config._buildkite
         config.pluginmanager.unregister(plugin)
+
+def pytest_addoption(parser):
+    """add custom option to pytest"""
+    group = parser.getgroup('buildkite', 'Buildkite Test Collector')
+    group.addoption(
+        '--json',
+        default=None,
+        action='store',
+        dest="jsonpath",
+        metavar="path",
+        help='save json file at given path'
+    )

--- a/src/buildkite_test_collector/pytest_plugin/buildkite_plugin.py
+++ b/src/buildkite_test_collector/pytest_plugin/buildkite_plugin.py
@@ -1,9 +1,9 @@
 """Buildkite test collector plugin for Pytest"""
+import json
 
 from uuid import uuid4
 
 from ..collector.payload import TestData
-
 
 class BuildkitePlugin:
     """Buildkite test collector plugin for Pytest"""
@@ -51,3 +51,8 @@ class BuildkitePlugin:
 
             del self.in_flight[nodeid]
             self.payload = self.payload.push_test_data(test_data)
+
+    def save_payload_as_json(self, path):
+        """ Save payload into a json file """
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(self.payload.as_json(), f)

--- a/src/buildkite_test_collector/pytest_plugin/buildkite_plugin.py
+++ b/src/buildkite_test_collector/pytest_plugin/buildkite_plugin.py
@@ -55,4 +55,4 @@ class BuildkitePlugin:
     def save_payload_as_json(self, path):
         """ Save payload into a json file """
         with open(path, "w", encoding="utf-8") as f:
-            json.dump(self.payload.as_json(), f)
+            json.dump(self.payload.as_json()["data"], f)

--- a/tests/buildkite_test_collector/pytest_plugin/test_plugin.py
+++ b/tests/buildkite_test_collector/pytest_plugin/test_plugin.py
@@ -1,6 +1,8 @@
 from buildkite_test_collector.pytest_plugin import BuildkitePlugin
 from buildkite_test_collector.collector.payload import Payload
+from pathlib import Path
 
+import json
 
 def test_runtest_logstart_with_unstarted_payload(fake_env):
     payload = Payload.init(fake_env)
@@ -11,3 +13,13 @@ def test_runtest_logstart_with_unstarted_payload(fake_env):
     plugin.pytest_runtest_logstart("wat::when", [1, 2])
 
     assert plugin.payload.started_at is not None
+
+
+def test_save_json_payload(fake_env, tmp_path):
+    payload = Payload.init(fake_env)
+    plugin = BuildkitePlugin(payload)
+
+    path = tmp_path / "result.json"
+    plugin.save_payload_as_json(path)
+
+    assert path.read_text() == json.dumps(payload.as_json())

--- a/tests/buildkite_test_collector/pytest_plugin/test_plugin.py
+++ b/tests/buildkite_test_collector/pytest_plugin/test_plugin.py
@@ -15,11 +15,14 @@ def test_runtest_logstart_with_unstarted_payload(fake_env):
     assert plugin.payload.started_at is not None
 
 
-def test_save_json_payload(fake_env, tmp_path):
+def test_save_json_payload(fake_env, tmp_path, successful_test):
     payload = Payload.init(fake_env)
+    payload = Payload.started(payload)
+    payload = payload.push_test_data(successful_test)
+
     plugin = BuildkitePlugin(payload)
 
     path = tmp_path / "result.json"
     plugin.save_payload_as_json(path)
 
-    assert path.read_text() == json.dumps(payload.as_json())
+    assert path.read_text() == json.dumps([successful_test.as_json(payload.started_at)])


### PR DESCRIPTION
We’re integrating [bktec](https://github.com/buildkite/test-engine-client) with pytest, which requires reading the output from pytest. While pytest has native JUnit XML, it lacks certain information required by `bktec`. Since `bktec` relies on this collector, it’s more convenient to save the JSON output from this collector, so `bktec` can read it.

To save json payload to a file, you need to add `--json=path` option to the `pytest command`. For example
```
pytest --json=result.json
```