### PR TITLE
Add `file_name` to test payload

### DIFF
--- a/src/buildkite_test_collector/collector/payload.py
+++ b/src/buildkite_test_collector/collector/payload.py
@@ -112,20 +112,24 @@ class TestData:
     name: str
     history: TestHistory
     location: Optional[str] = None
+    file_name: Optional[str] = None
     result: Union[TestResultPassed, TestResultFailed,
                   TestResultSkipped, None] = None
 
     @classmethod
     def start(cls, id: UUID,
+              *,
               scope: str,
               name: str,
-              location: Optional[str] = None) -> 'TestData':
+              location: Optional[str] = None,
+              file_name: Optional[str] = None) -> 'TestData':
         """Build a new instance with it's start_at time set to now"""
         return cls(
             id=id,
             scope=scope,
             name=name,
             location=location,
+            file_name=file_name,
             history=TestHistory(start_at=Instant.now())
         )
 
@@ -167,6 +171,7 @@ class TestData:
             "scope": self.scope,
             "name": self.name,
             "location": self.location,
+            "file_name": self.file_name,
             "history": self.history.as_json(started_at)
         }
 

--- a/src/buildkite_test_collector/pytest_plugin/buildkite_plugin.py
+++ b/src/buildkite_test_collector/pytest_plugin/buildkite_plugin.py
@@ -19,11 +19,14 @@ class BuildkitePlugin:
             self.payload = self.payload.started()
 
         chunks = nodeid.split("::")
-        scope = "::".join(chunks[:-1])
-        name = chunks[-1]
-        location = f"{location[0]}:{location[1]}"
 
-        test_data = TestData.start(uuid4(), scope, name, location)
+        test_data = TestData.start(
+            uuid4(),
+            scope="::".join(chunks[:-1]),
+            name=chunks[-1],
+            file_name=location[0],
+            location=f"{location[0]}:{location[1]}"
+        )
         self.in_flight[nodeid] = test_data
 
     def pytest_runtest_logreport(self, report):

--- a/tests/buildkite_test_collector/collector/test_payload.py
+++ b/tests/buildkite_test_collector/collector/test_payload.py
@@ -147,6 +147,7 @@ def test_test_data_as_json(incomplete_test):
     assert json["scope"] == incomplete_test.scope
     assert json["name"] == incomplete_test.name
     assert json["location"] == incomplete_test.location
+    assert json["file_name"] == incomplete_test.file_name
     assert json["history"] == incomplete_test.history.as_json(now)
 
 

--- a/tests/buildkite_test_collector/conftest.py
+++ b/tests/buildkite_test_collector/conftest.py
@@ -18,6 +18,7 @@ def successful_test(history_finished) -> TestData:
         scope="wyld stallyns",
         name="san dimas meltdown",
         location="san_dimas_meltdown.py:1",
+        file_name="san_dimas_meltdown.py",
         result=TestResultPassed(),
         history=history_finished
     )
@@ -40,6 +41,7 @@ def incomplete_test(history_started) -> TestData:
         scope="wyld stallyns",
         name="san dimas meltdown",
         location="san_dimas_meltdown.py:1",
+        file_name="san_dimas_meltdown.py",
         result=None,
         history=history_started
     )


### PR DESCRIPTION
Add `file_name` to test payload as it is currently missing.

Reference: https://buildkite.com/docs/test-engine/importing-json#json-test-results-data-reference-test-result-objects