### PR TITLE
PIE-3516 part 2: use AWS SSM instead and simplify the release workflow

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -2,22 +2,30 @@ agents:
   queue: hosted
 
 steps:
-  # This is most to prevent we accidentally tag things.
-  - block: "OK to release?"
-
   - command: ".buildkite/steps/release-pypi"
     label: ":pypi:"
-    if: build.tag != null
+    if: build.message =~ /\[release\]/i && build.branch == "main"
     env:
       # > The username to authenticate to the repository (package index) as. Has no effect on PyPI
       # It should be a noop, I set it anyway to prevent prompt showing up.
       TWINE_USERNAME: __token__
     plugins:
-      - cluster-secrets#v1.0.0:
-          variables:
-            TWINE_PASSWORD: test-collector-python-pypi-api-token
+      - aws-assume-role-with-web-identity#v1.2.0:
+          role-arn: "arn:aws:iam::445615400570:role/pipeline-buildkite-test-collector-python-build"
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+            - build_branch
+      - aws-ssm#v1.0.0:
+          parameters:
+            TWINE_PASSWORD: /pipelines/buildkite/test-collector-python-release/pypi-api-token
+      - ecr#v2.9.0:
+          login: true
+          account_ids: "public.ecr.aws"
+          region: "us-east-1"
       - docker#v5.12.0:
-          image: "python:3.13"
+          image: "public.ecr.aws/docker/library/python:3.13.2-bookworm"
           environment:
             - TWINE_USERNAME
             - TWINE_PASSWORD

--- a/README.md
+++ b/README.md
@@ -84,12 +84,10 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/buildk
 
 ## 🚀 Releasing
 
-1. Open a new PR bumping the version number in `constants.py`.
-2. Get the PR approved and merged.
-3. Tag the merge commit with the same version number, then git push.
-4. Go to release pipeline and approve the pipeline to execute.
-5. (Optional) In the event of step 4 failure, run `.buildkite/steps/release-pypi` locally with your own credentials.
-6. Create a [new github release](https://github.com/buildkite/test-collector-python/releases).
+1. Open a new PR bumping the version number in `constants.py`, make sure the PR title contains `[release]`.
+2. Get the PR approved and merged, this will trigger the release pipeline.
+3. (Optional) In the event of step 3 failure, run `.buildkite/steps/release-pypi` locally with your own credentials.
+4. Create a [new github release](https://github.com/buildkite/test-collector-python/releases) for prosperity, you can create a tag as you create the release.
 
 ## 📜 License
 


### PR DESCRIPTION
* After clarifying with other engineers, I replace Buildkite Secret with AWS SSM. 
* I also tweak the release flow so it's much simplified. 

If this is successful, we can probably apply the same practice to other Test Engine open source repos. 