### PR TITLE
Add execution level tagging

### DIFF
--- a/src/buildkite_test_collector/collector/payload.py
+++ b/src/buildkite_test_collector/collector/payload.py
@@ -115,7 +115,7 @@ class TestData:
     history: TestHistory
     location: Optional[str] = None
     file_name: Optional[str] = None
-    tags: dict = field(default_factory=dict)
+    tags: Dict[str,str] = field(default_factory=dict)
     result: Union[TestResultPassed, TestResultFailed,
                   TestResultSkipped, None] = None
 
@@ -136,8 +136,11 @@ class TestData:
             history=TestHistory(start_at=Instant.now())
         )
 
-    def tag_execution(self, key, val) -> 'TestData':
+    def tag_execution(self, key: str, val: str) -> 'TestData':
         """Set tag to test execution"""
+        if not isinstance(key, str) or not isinstance(val, str):
+            raise TypeError("Expected string for key and value")
+
         self.tags[key] = val
 
     def finish(self) -> 'TestData':

--- a/src/buildkite_test_collector/pytest_plugin/__init__.py
+++ b/src/buildkite_test_collector/pytest_plugin/__init__.py
@@ -28,10 +28,13 @@ def pytest_configure(config):
     env = detect_env()
     debug = environ.get("BUILDKITE_ANALYTICS_DEBUG_ENABLED")
 
+    config.addinivalue_line("markers", "execution_tag(key, val): add tag to test execution for Buildkite Test Collector")
+
     if env:
         plugin = BuildkitePlugin(Payload.init(env))
         setattr(config, '_buildkite', plugin)
         config.pluginmanager.register(plugin)
+
     elif debug:
         warning("Unable to detect CI environment.  No test analytics will be sent.")
 

--- a/src/buildkite_test_collector/pytest_plugin/__init__.py
+++ b/src/buildkite_test_collector/pytest_plugin/__init__.py
@@ -28,7 +28,7 @@ def pytest_configure(config):
     env = detect_env()
     debug = environ.get("BUILDKITE_ANALYTICS_DEBUG_ENABLED")
 
-    config.addinivalue_line("markers", "execution_tag(key, val): add tag to test execution for Buildkite Test Collector")
+    config.addinivalue_line("markers", "execution_tag(key, value): add tag to test execution for Buildkite Test Collector. Both key and value must be a string.")
 
     if env:
         plugin = BuildkitePlugin(Payload.init(env))

--- a/src/buildkite_test_collector/pytest_plugin/buildkite_plugin.py
+++ b/src/buildkite_test_collector/pytest_plugin/buildkite_plugin.py
@@ -29,9 +29,18 @@ class BuildkitePlugin:
         )
         self.in_flight[nodeid] = test_data
 
+    def pytest_runtest_teardown(self, item):
+        """pytest_runtest_hook hook callback to collect execution_tag"""
+        test_data = self.in_flight.get(item.nodeid)
+
+        if test_data:
+            tags = item.iter_markers("execution_tag")
+            for tag in tags:
+                test_data.tag_execution(tag.args[0], tag.args[1])
+
     def pytest_runtest_logreport(self, report):
         """pytest_runtest_logreport hook callback"""
-        if report.when != 'call':
+        if report.when != 'teardown':
             return
 
         nodeid = report.nodeid

--- a/tests/buildkite_test_collector/collector/test_payload.py
+++ b/tests/buildkite_test_collector/collector/test_payload.py
@@ -168,3 +168,14 @@ def test_test_data_as_json_when_skipped(skipped_test):
     json = skipped_test.as_json(Instant.now())
 
     assert json["result"] == "skipped"
+
+def test_test_data_tag_execution(successful_test):
+    successful_test.tag_execution("owner", "test-engine")
+    successful_test.tag_execution("python.version", "3.12.3")
+
+    expected_tags = {"owner": "test-engine", "python.version": "3.12.3"}
+
+    assert successful_test.tags == expected_tags
+
+    json = successful_test.as_json(Instant.now())
+    assert json["tags"] == {"owner": "test-engine", "python.version": "3.12.3"}

--- a/tests/buildkite_test_collector/collector/test_payload.py
+++ b/tests/buildkite_test_collector/collector/test_payload.py
@@ -169,13 +169,21 @@ def test_test_data_as_json_when_skipped(skipped_test):
 
     assert json["result"] == "skipped"
 
-def test_test_data_tag_execution(successful_test):
-    successful_test.tag_execution("owner", "test-engine")
-    successful_test.tag_execution("python.version", "3.12.3")
+class TestTestDataTagExecution:
+    def test_test_data_tag_execution(self, successful_test):
+        successful_test.tag_execution("owner", "test-engine")
+        successful_test.tag_execution("python.version", "3.12.3")
 
-    expected_tags = {"owner": "test-engine", "python.version": "3.12.3"}
+        expected_tags = {"owner": "test-engine", "python.version": "3.12.3"}
 
-    assert successful_test.tags == expected_tags
+        assert successful_test.tags == expected_tags
 
-    json = successful_test.as_json(Instant.now())
-    assert json["tags"] == {"owner": "test-engine", "python.version": "3.12.3"}
+        json = successful_test.as_json(Instant.now())
+        assert json["tags"] == {"owner": "test-engine", "python.version": "3.12.3"}
+
+    def test_test_data_tag_execution_non_string(self, successful_test):
+        with pytest.raises(TypeError):
+            successful_test.tag_execution("feature", True)
+
+        with pytest.raises(TypeError):
+            successful_test.tag_execution(777, "lucky")


### PR DESCRIPTION
Add execution level tagging using `execution_tag` custom marker. The test collector will send all tags marked on each test to Buildkite Test Engine. See pytest's [custom markers ](https://docs.pytest.org/en/stable/example/markers.html)documentation.

tagging individual tests using decorator:
```py
import pytest

@pytest.mark.execution_tag("key", "value")
@pytest.mark.execution_tag("another.key", "value")
def test_add():
     assert 1 + 1 == 2
```

tagging all tests in a test class using decorator:
```py
import pytest

@pytest.mark.execution_tag("key", "value")
@pytest.mark.execution_tag("another.key", "value")
class TestSubstract:
    def test_positive(self):
        assert 5 - 4 == 1

    def test_negative(self):
        assert 2 - 3 = -1 
```

tagging all tests in a module using `pytestmark` helper
```py
import pytest

pytestmark=[
    pytest.mark.execution_tag("key", "value"),
    pytest.mark.execution_tag("another.key", "value")
]

def test_add():
     assert 1 + 1 == 2
```


tagging tests from a hook:
```py
def pytest_runtest_setup(item):
    item.add_marker(pytest.mark.execution_tag("key", "value"))
    item.add_marker(pytest.mark.execution_tag("another.key", "value"))
```