### PR TITLE
Remove `CI` environment requirement

### DIFF
--- a/src/buildkite_test_collector/collector/run_env.py
+++ b/src/buildkite_test_collector/collector/run_env.py
@@ -78,9 +78,6 @@ def __circle_ci_env() -> Optional['RuntimeEnvironment']:
 
 
 def __generic_env() -> Optional['RuntimeEnvironment']:
-    if __get_env("CI") is None:
-        return None
-
     return RuntimeEnvironment(
         ci="generic",
         key=str(uuid4()),

--- a/src/buildkite_test_collector/pytest_plugin/__init__.py
+++ b/src/buildkite_test_collector/pytest_plugin/__init__.py
@@ -26,17 +26,12 @@ def spans(request):
 def pytest_configure(config):
     """pytest_configure hook callback"""
     env = detect_env()
-    debug = environ.get("BUILDKITE_ANALYTICS_DEBUG_ENABLED")
 
     config.addinivalue_line("markers", "execution_tag(key, value): add tag to test execution for Buildkite Test Collector. Both key and value must be a string.")
 
-    if env:
-        plugin = BuildkitePlugin(Payload.init(env))
-        setattr(config, '_buildkite', plugin)
-        config.pluginmanager.register(plugin)
-
-    elif debug:
-        warning("Unable to detect CI environment.  No test analytics will be sent.")
+    plugin = BuildkitePlugin(Payload.init(env))
+    setattr(config, '_buildkite', plugin)
+    config.pluginmanager.register(plugin)
 
 
 @pytest.hookimpl

--- a/tests/buildkite_test_collector/collector/test_run_env.py
+++ b/tests/buildkite_test_collector/collector/test_run_env.py
@@ -7,11 +7,6 @@ from buildkite_test_collector.collector.constants import COLLECTOR_NAME, VERSION
 from buildkite_test_collector.collector.run_env import detect_env
 
 
-def test_detect_env_with_no_env_returns_none():
-    with mock.patch.dict(os.environ, {}, clear=True):
-        assert detect_env() is None
-
-
 def test_detect_env_with_buildkite_api_env_vars_returns_the_correct_environment():
     id = str(uuid4())
     commit = uuid4().hex
@@ -96,9 +91,7 @@ def test_detect_env_with_circle_ci_env_vars_returns_the_correct_environment():
         assert runtime_env.message == "excellent adventure"
 
 def test_detect_env_with_generic_env_vars():
-    env = {
-        "CI": "true"
-    }
+    env = {}
 
     with mock.patch.dict(os.environ, env, clear=True):
         runtime_env = detect_env()


### PR DESCRIPTION
Currently, the test collector doesn’t function if the `CI` environment is missing. Since there’s no compelling reason to requires a `CI` environment for running the test collector, we can remove these restrictions.
