### PR TITLE
[release] 1.0.1rc1: more logs and defensive mechanism for test collection

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+# Python files
+[*.py]
+indent_style = space
+indent_size = 4
+
+# YAML files
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ __pycache__
 .env*
 
 .direnv/*
+
+build

--- a/src/buildkite_test_collector/collector/api.py
+++ b/src/buildkite_test_collector/collector/api.py
@@ -2,22 +2,21 @@
 
 from typing import Optional
 from os import environ
-from sys import stderr
 import traceback
 from requests import post, Response
 from requests.exceptions import InvalidHeader, HTTPError
 from .payload import Payload
+from ..pytest_plugin.logger import logger
 
 
 def submit(payload: Payload, batch_size=100) -> Optional[Response]:
     """Submit a payload to the API"""
     token = environ.get("BUILDKITE_ANALYTICS_TOKEN")
-    debug = environ.get("BUILDKITE_ANALYTICS_DEBUG_ENABLED")
     api_url = environ.get("BUILDKITE_ANALYTICS_API_URL", "https://analytics-api.buildkite.com/v1")
     response = None
 
-    if debug and not token:
-        print("Warning: No `BUILDKITE_ANALYTICS_TOKEN` environment variable present", file=stderr)
+    if not token:
+        logger.warning("No `BUILDKITE_ANALYTICS_TOKEN` environment variable present")
 
     if token:
         try:
@@ -32,12 +31,12 @@ def submit(payload: Payload, batch_size=100) -> Optional[Response]:
                 response.raise_for_status()
                 return response
         except InvalidHeader as error:
-            print("Warning: Invalid `BUILDKITE_ANALYTICS_TOKEN` environment variable", file=stderr)
-            print(error, file=stderr)
+            logger.warning("Invalid `BUILDKITE_ANALYTICS_TOKEN` environment variable")
+            logger.warning(error)
         except HTTPError as err:
-            print("Warning: Failed to uploads test results to buildkite", file=stderr)
-            print(err, file=stderr)
-        except Exception: # pylint: disable=broad-except
+            logger.warning("Failed to uploads test results to buildkite")
+            logger.warning(err)
+        except Exception:  # pylint: disable=broad-except
             error_message = traceback.format_exc()
-            print(error_message, file=stderr)
+            logger.warning(error_message)
     return None

--- a/src/buildkite_test_collector/collector/constants.py
+++ b/src/buildkite_test_collector/collector/constants.py
@@ -3,4 +3,4 @@
 """This module defines collector-level constants."""
 
 COLLECTOR_NAME='buildkite-test-collector'
-VERSION='1.0.0'
+VERSION='1.0.1rc1'

--- a/src/buildkite_test_collector/pytest_plugin/__init__.py
+++ b/src/buildkite_test_collector/pytest_plugin/__init__.py
@@ -1,9 +1,6 @@
 # pylint: disable=line-too-long
 """Buildkite test collector for Pytest."""
 
-from logging import warning
-from os import environ
-
 import pytest
 
 from ..collector.payload import Payload

--- a/src/buildkite_test_collector/pytest_plugin/logger.py
+++ b/src/buildkite_test_collector/pytest_plugin/logger.py
@@ -1,0 +1,38 @@
+"""A plugin internal logger, use DEBUG=1 env var to turn on all debug logs"""
+import os
+import logging
+
+def setup_logger(name=__name__):
+    """
+    Configure and return a logger with the specified name.
+
+    The logger's level is set based on the DEBUG environment variable.
+    If DEBUG=1, the level is set to DEBUG, otherwise it's set to INFO.
+
+    Args:
+        name (str): The name for the logger. Defaults to the current module name.
+
+    Returns:
+        logging.Logger: A configured logger instance.
+    """
+    l = logging.getLogger(name)
+
+    # Set level based on DEBUG env var
+    l.setLevel(logging.DEBUG if os.getenv("DEBUG") == "1" else logging.INFO)
+
+    # Add handler only if none exists (prevents duplicate logs)
+    if not l.handlers:
+        handler = logging.StreamHandler()  # Log to console
+        formatter = logging.Formatter(
+            "%(name)s - %(levelname)s - %(message)s"
+        )
+        handler.setFormatter(formatter)
+        l.addHandler(handler)
+
+    # Optional: Stop propagation to root logger
+    l.propagate = False
+
+    return l
+
+# Example default logger (optional)
+logger = setup_logger("buildkite-test-collector")

--- a/tests/buildkite_test_collector/collector/test_api.py
+++ b/tests/buildkite_test_collector/collector/test_api.py
@@ -42,7 +42,7 @@ def test_submit_with_payload_timeout_captures_ConnectTimeout_error(capfd, succes
         result = submit(payload)
         captured = capfd.readouterr()
 
-        assert captured.err.startswith("Traceback")
+        assert captured.err.startswith("buildkite-test-collector - WARNING -")
         assert "ConnectTimeout" in captured.err
 
 @responses.activate
@@ -62,7 +62,7 @@ def test_submit_with_payload_timeout_captures_ReadTimeout_error(capfd, successfu
         result = submit(payload)
         captured = capfd.readouterr()
 
-        assert captured.err.startswith("Traceback")
+        assert captured.err.startswith("buildkite-test-collector - WARNING -")
         assert "ReadTimeout" in captured.err
 
 @responses.activate


### PR DESCRIPTION
We had one report of Test Result upload contains empty data. User claimed that this only started happening since `v1.0.0`. 

I couldn't not reproduce the same issue (using the same pytest version) so I had to make a logical guess:

* The fact that upload works means our plugin is successfully loaded. 
* The fact that `v0.2.0` works means there is no problem in our `pytest_runtest_logreport ` hook (v1 introduced `pytest_runtest_teardown` hook to collect test, v0.2 relies solely on `pytest_runtest_logreport`). 
* So my guess is that something prevent `pytest_runtest_teardown` from running. 

---

So I added lots of debug logging, user can opt-in to seeing them by setting env var `DEBUG=1`. 

I also add some a defensive mechanism: another `pytest_runtest_logfinish` hook hoping as a fallback option. 
