### PR TITLE
[release] 1.0.1rc2: support xdist properly

### DIFF
--- a/src/buildkite_test_collector/collector/constants.py
+++ b/src/buildkite_test_collector/collector/constants.py
@@ -3,4 +3,4 @@
 """This module defines collector-level constants."""
 
 COLLECTOR_NAME='buildkite-test-collector'
-VERSION='1.0.1rc1'
+VERSION='1.0.1rc2'

--- a/src/buildkite_test_collector/collector/payload.py
+++ b/src/buildkite_test_collector/collector/payload.py
@@ -5,6 +5,8 @@ from typing import Dict, Tuple, Optional, Union, Literal
 from datetime import timedelta
 from uuid import UUID
 
+from ..pytest_plugin.logger import logger
+
 from .instant import Instant
 from .run_env import RuntimeEnvironment
 
@@ -215,6 +217,7 @@ class Payload:
     @classmethod
     def init(cls, run_env: RuntimeEnvironment) -> 'Payload':
         """Create a new instance of payload with the provided runtime environment"""
+
         return cls(
             run_env=run_env,
             data=(),
@@ -224,10 +227,13 @@ class Payload:
 
     def as_json(self) -> JsonDict:
         """Convert into a Dict suitable for eventual serialisation to JSON"""
-        finished_data = filter(
+        finished_data = list(filter(
             lambda td: td.is_finished(),
             self.data
-        )
+        ))
+
+        if len(finished_data) < len(self.data):
+            logger.warning('Unexpected unfinished test data, skipping unfinished test records...')
 
         return {
             "format": "json",

--- a/src/buildkite_test_collector/collector/run_env.py
+++ b/src/buildkite_test_collector/collector/run_env.py
@@ -77,7 +77,7 @@ def __circle_ci_env() -> Optional['RuntimeEnvironment']:
     )
 
 
-def __generic_env() -> Optional['RuntimeEnvironment']:
+def __generic_env() -> 'RuntimeEnvironment':
     return RuntimeEnvironment(
         ci="generic",
         key=str(uuid4()),
@@ -120,7 +120,7 @@ class RuntimeEnvironment:
         return {k: v for k, v in attrs.items() if v is not None}
 
 
-def detect_env() -> Optional['RuntimeEnvironment']:
+def detect_env() -> RuntimeEnvironment:
     """Attempt to detect the CI system we're running in"""
     return __buildkite_env() or \
         __github_actions_env() or \

--- a/src/buildkite_test_collector/pytest_plugin/logger.py
+++ b/src/buildkite_test_collector/pytest_plugin/logger.py
@@ -1,13 +1,10 @@
-"""A plugin internal logger, use DEBUG=1 env var to turn on all debug logs"""
+"""A plugin internal logger"""
 import os
 import logging
 
 def setup_logger(name=__name__):
     """
     Configure and return a logger with the specified name.
-
-    The logger's level is set based on the DEBUG environment variable.
-    If DEBUG=1, the level is set to DEBUG, otherwise it's set to INFO.
 
     Args:
         name (str): The name for the logger. Defaults to the current module name.
@@ -18,7 +15,8 @@ def setup_logger(name=__name__):
     l = logging.getLogger(name)
 
     # Set level based on DEBUG env var
-    l.setLevel(logging.DEBUG if os.getenv("DEBUG") == "1" else logging.INFO)
+    debug_enabled = os.getenv("BUILDKITE_ANALYTICS_DEBUG_ENABLED") == "1"
+    l.setLevel(logging.DEBUG if debug_enabled else logging.INFO)
 
     # Add handler only if none exists (prevents duplicate logs)
     if not l.handlers:


### PR DESCRIPTION
We discovered that `xdist` doesn't work with our `1.0.0` version, the reason can be summarize in one sentence: when xdist is enabled, some hooks will get totally ignored. 

But the fix is not so simple, because there isn't an official document saying which hooks will be skipped under what situation. So after a lot of experiments, I come to the following change: 

* use `pytest_runtest_makereport` to replace `pytest_runtest_teardown` hook (this gets totally skipped by `xdist`). 
* When xdist is activated, use worker thread to upload test result so we can read tags.  
* Add extra logging for unfinished test data situation.
* As a side change, I went back to using `BUILDKITE_ANALYTICS_DEBUG_ENABLED` as debug envvar instead of the general `DEBUG` env var.


I have tested extensively in my local env, can confirm this work with or without `xdist`. 