### PR TITLE
Abstract `os.environ` so real env doesn't interfere with tests

### DIFF
--- a/src/buildkite_test_collector/collector/api.py
+++ b/src/buildkite_test_collector/collector/api.py
@@ -1,7 +1,6 @@
 """Buildkite Test Analytics API"""
 
-from typing import Any, Generator, Optional
-from os import environ
+from typing import Any, Generator, Optional, Mapping
 import traceback
 from requests import post, Response
 from requests.exceptions import InvalidHeader, HTTPError
@@ -9,37 +8,44 @@ from .payload import Payload
 from ..pytest_plugin.logger import logger
 
 
-def submit(payload: Payload, batch_size=100) -> Generator[Optional[Response], Any, Any]:
-    """Submit a payload to the API"""
-    token = environ.get("BUILDKITE_ANALYTICS_TOKEN")
-    api_url = environ.get("BUILDKITE_ANALYTICS_API_URL", "https://analytics-api.buildkite.com/v1")
-    response = None
+class API:
+    """Buildkite Test Analytics API client"""
 
-    if not token:
-        logger.warning("No `BUILDKITE_ANALYTICS_TOKEN` environment variable present")
-        yield None
+    def __init__(self, env: Mapping[str, Optional[str]]):
+        """Initialize the API client with environment variables"""
+        self.env = env
 
-    else:
-        for payload_slice in payload.into_batches(batch_size):
-            try:
-                response = post(api_url + "/uploads",
-                                json=payload_slice.as_json(),
-                                headers={
-                                    "Content-Type": "application/json",
-                                    "Authorization": f"Token token=\"{token}\""
-                                },
-                                timeout=60)
-                response.raise_for_status()
-                yield response
-            except InvalidHeader as error:
-                logger.warning("Invalid `BUILDKITE_ANALYTICS_TOKEN` environment variable")
-                logger.warning(error)
-                yield None
-            except HTTPError as err:
-                logger.warning("Failed to uploads test results to buildkite")
-                logger.warning(err)
-                yield None
-            except Exception:  # pylint: disable=broad-except
-                error_message = traceback.format_exc()
-                logger.warning(error_message)
-                yield None
+    def submit(self, payload: Payload, batch_size=100) -> Generator[Optional[Response], Any, Any]:
+        """Submit a payload to the API"""
+        token = self.env.get("BUILDKITE_ANALYTICS_TOKEN")
+        api_url = self.env.get("BUILDKITE_ANALYTICS_API_URL") or "https://analytics-api.buildkite.com/v1"
+        response = None
+
+        if not token:
+            logger.warning("No `BUILDKITE_ANALYTICS_TOKEN` environment variable present")
+            yield None
+
+        else:
+            for payload_slice in payload.into_batches(batch_size):
+                try:
+                    response = post(api_url + "/uploads",
+                                    json=payload_slice.as_json(),
+                                    headers={
+                                        "Content-Type": "application/json",
+                                        "Authorization": f"Token token=\"{token}\""
+                                    },
+                                    timeout=60)
+                    response.raise_for_status()
+                    yield response
+                except InvalidHeader as error:
+                    logger.warning("Invalid `BUILDKITE_ANALYTICS_TOKEN` environment variable")
+                    logger.warning(error)
+                    yield None
+                except HTTPError as err:
+                    logger.warning("Failed to uploads test results to buildkite")
+                    logger.warning(err)
+                    yield None
+                except Exception:  # pylint: disable=broad-except
+                    error_message = traceback.format_exc()
+                    logger.warning(error_message)
+                    yield None

--- a/tests/buildkite_test_collector/collector/test_api.py
+++ b/tests/buildkite_test_collector/collector/test_api.py
@@ -6,24 +6,26 @@ import responses
 import pytest
 import sys
 
-from buildkite_test_collector.collector.run_env import detect_env
-from buildkite_test_collector.collector.api import submit
+from buildkite_test_collector.collector.run_env import RunEnvBuilder
+from buildkite_test_collector.collector.api import API
 from buildkite_test_collector.collector.payload import Payload
 from requests.exceptions import ReadTimeout, ConnectTimeout
 
 
 def test_submit_with_missing_api_key_environment_variable_returns_none():
-    with mock.patch.dict(os.environ, {"CI": "true", "BUILDKITE_ANALYTICS_TOKEN": ""}):
-        payload = Payload.init(detect_env())
+    env = {"CI": "true", "BUILDKITE_ANALYTICS_TOKEN": None}
+    payload = Payload.init(RunEnvBuilder(env).build())
 
-        assert next(submit(payload)) is None
+    api = API(env)
+    assert next(api.submit(payload)) is None
 
 
 def test_submit_with_invalid_api_key_environment_variable_returns_none():
-    with mock.patch.dict(os.environ, {"CI": "true", "BUILDKITE_ANALYTICS_TOKEN": "\n"}):
-        payload = Payload.init(detect_env())
+    env = {"CI": "true", "BUILDKITE_ANALYTICS_TOKEN": "\n"}
+    payload = Payload.init(RunEnvBuilder(env).build())
 
-        assert next(submit(payload)) is None
+    api = API(env)
+    assert next(api.submit(payload)) is None
 
 @responses.activate
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")
@@ -33,17 +35,18 @@ def test_submit_with_payload_timeout_captures_ConnectTimeout_error(capfd, succes
         "https://analytics-api.buildkite.com/v1/uploads",
         body=ConnectTimeout("Error"))
 
-    with mock.patch.dict(os.environ, {"CI": "true", "BUILDKITE_ANALYTICS_TOKEN": str(uuid4())}):
-        payload = Payload.init(detect_env())
-        payload = Payload.started(payload)
+    env = {"CI": "true", "BUILDKITE_ANALYTICS_TOKEN": str(uuid4())}
+    payload = Payload.init(RunEnvBuilder(env).build())
+    payload = Payload.started(payload)
 
-        payload = payload.push_test_data(successful_test)
+    payload = payload.push_test_data(successful_test)
 
-        result = next(submit(payload))
-        captured = capfd.readouterr()
+    api = API(env)
+    result = next(api.submit(payload))
+    captured = capfd.readouterr()
 
-        assert captured.err.startswith("buildkite-test-collector - WARNING -")
-        assert "ConnectTimeout" in captured.err
+    assert captured.err.startswith("buildkite-test-collector - WARNING -")
+    assert "ConnectTimeout" in captured.err
 
 @responses.activate
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")
@@ -53,17 +56,18 @@ def test_submit_with_payload_timeout_captures_ReadTimeout_error(capfd, successfu
         "https://analytics-api.buildkite.com/v1/uploads",
         body=ReadTimeout("Error"))
 
-    with mock.patch.dict(os.environ, {"CI": "true", "BUILDKITE_ANALYTICS_TOKEN": str(uuid4())}):
-        payload = Payload.init(detect_env())
-        payload = Payload.started(payload)
+    env = {"CI": "true", "BUILDKITE_ANALYTICS_TOKEN": str(uuid4())}
+    payload = Payload.init(RunEnvBuilder(env).build())
+    payload = Payload.started(payload)
 
-        payload = payload.push_test_data(successful_test)
+    payload = payload.push_test_data(successful_test)
 
-        result = next(submit(payload))
-        captured = capfd.readouterr()
+    api = API(env)
+    result = next(api.submit(payload))
+    captured = capfd.readouterr()
 
-        assert captured.err.startswith("buildkite-test-collector - WARNING -")
-        assert "ReadTimeout" in captured.err
+    assert captured.err.startswith("buildkite-test-collector - WARNING -")
+    assert "ReadTimeout" in captured.err
 
 @responses.activate
 def test_submit_with_payload_returns_an_api_response(successful_test):
@@ -78,21 +82,22 @@ def test_submit_with_payload_returns_an_api_response(successful_test):
               'run_url': 'https://buildkite.com/organizations/alembic/analytics/suites/test/runs/52c5d9f6-a4f2-4a2d-a1e6-993335789c92'},
         status=202)
 
-    with mock.patch.dict(os.environ, {"CI": "true", "BUILDKITE_ANALYTICS_TOKEN": str(uuid4())}):
-        payload = Payload.init(detect_env())
-        payload = Payload.started(payload)
+    env = {"CI": "true", "BUILDKITE_ANALYTICS_TOKEN": str(uuid4())}
+    payload = Payload.init(RunEnvBuilder(env).build())
+    payload = Payload.started(payload)
 
-        payload = payload.push_test_data(successful_test)
+    payload = payload.push_test_data(successful_test)
 
-        result = next(submit(payload))
-        assert result
+    api = API(env)
+    result = next(api.submit(payload))
+    assert result
 
-        assert result.status_code >= 200
-        assert result.status_code < 300
+    assert result.status_code >= 200
+    assert result.status_code < 300
 
-        json = result.json()
-        assert len(json["errors"]) == 0
-        assert json['queued'] == 1
+    json = result.json()
+    assert len(json["errors"]) == 0
+    assert json['queued'] == 1
 
 @responses.activate
 def test_submit_with_bad_response(successful_test):
@@ -102,15 +107,16 @@ def test_submit_with_bad_response(successful_test):
         json={'error': str(uuid4())},
         status=401)
 
-    with mock.patch.dict(os.environ, {"CI": "true", "BUILDKITE_ANALYTICS_TOKEN": str(uuid4())}):
-        payload = Payload.init(detect_env())
-        payload = Payload.started(payload)
+    env = {"CI": "true", "BUILDKITE_ANALYTICS_TOKEN": str(uuid4())}
+    payload = Payload.init(RunEnvBuilder(env).build())
+    payload = Payload.started(payload)
 
-        payload = payload.push_test_data(successful_test)
+    payload = payload.push_test_data(successful_test)
 
-        result = next(submit(payload))
+    api = API(env)
+    result = next(api.submit(payload))
 
-        assert result is None
+    assert result is None
 
 @responses.activate
 def test_submit_with_large_payload_batches_requests(successful_test, failed_test):
@@ -135,24 +141,25 @@ def test_submit_with_large_payload_batches_requests(successful_test, failed_test
               'run_url': 'https://buildkite.com/organizations/alembic/analytics/suites/test/runs/52c5d9f6-a4f2-4a2d-a1e6-993335789c92'},
         status=202)
 
-    with mock.patch.dict(os.environ, {"CI": "true", "BUILDKITE_ANALYTICS_TOKEN": str(uuid4())}):
-        payload = Payload.init(detect_env())
-        payload = Payload.started(payload)
+    env = {"CI": "true", "BUILDKITE_ANALYTICS_TOKEN": str(uuid4())}
+    payload = Payload.init(RunEnvBuilder(env).build())
+    payload = Payload.started(payload)
 
-        payload = payload.push_test_data(successful_test)
-        payload = payload.push_test_data(failed_test)
+    payload = payload.push_test_data(successful_test)
+    payload = payload.push_test_data(failed_test)
 
-        results = [response for response in submit(payload, batch_size=1)]
-        assert len(results) == 2
+    api = API(env)
+    results = [response for response in api.submit(payload, batch_size=1)]
+    assert len(results) == 2
 
-        for result in results:
-            assert result
-            assert result.status_code >= 200
-            assert result.status_code < 300
+    for result in results:
+        assert result
+        assert result.status_code >= 200
+        assert result.status_code < 300
 
-            json = result.json()
-            assert len(json["errors"]) == 0
-            assert json['queued'] == 1
+        json = result.json()
+        assert len(json["errors"]) == 0
+        assert json['queued'] == 1
 
 @responses.activate
 def test_submit_with_batches_and_errors(capfd, successful_test, failed_test):
@@ -171,29 +178,30 @@ def test_submit_with_batches_and_errors(capfd, successful_test, failed_test):
               'run_url': 'https://buildkite.com/organizations/alembic/analytics/suites/test/runs/52c5d9f6-a4f2-4a2d-a1e6-993335789c92'},
         status=202)
 
-    with mock.patch.dict(os.environ, {"CI": "true", "BUILDKITE_ANALYTICS_TOKEN": str(uuid4())}):
-        payload = Payload.init(detect_env())
-        payload = Payload.started(payload)
+    env = {"CI": "true", "BUILDKITE_ANALYTICS_TOKEN": str(uuid4())}
+    payload = Payload.init(RunEnvBuilder(env).build())
+    payload = Payload.started(payload)
 
-        payload = payload.push_test_data(successful_test)
-        payload = payload.push_test_data(failed_test)
+    payload = payload.push_test_data(successful_test)
+    payload = payload.push_test_data(failed_test)
 
-        results = [response for response in submit(payload, batch_size=1)]
-        assert len(results) == 2
+    api = API(env)
+    results = [response for response in api.submit(payload, batch_size=1)]
+    assert len(results) == 2
 
-        assert not results[0]
-        captured = capfd.readouterr()
-        assert captured.err.startswith("buildkite-test-collector - WARNING -")
-        assert "ConnectTimeout" in captured.err
+    assert not results[0]
+    captured = capfd.readouterr()
+    assert captured.err.startswith("buildkite-test-collector - WARNING -")
+    assert "ConnectTimeout" in captured.err
 
-        result = results[1]
-        assert result
-        assert result.status_code >= 200
-        assert result.status_code < 300
+    result = results[1]
+    assert result
+    assert result.status_code >= 200
+    assert result.status_code < 300
 
-        json = result.json()
-        assert len(json["errors"]) == 0
-        assert json['queued'] == 1
+    json = result.json()
+    assert len(json["errors"]) == 0
+    assert json['queued'] == 1
 
 @responses.activate
 def test_api_url_override(successful_test):
@@ -211,17 +219,17 @@ def test_api_url_override(successful_test):
         "BUILDKITE_ANALYTICS_TOKEN": str(uuid4()),
     }
 
-    with mock.patch.dict(os.environ, env):
-        payload = Payload.init(detect_env())
-        payload = Payload.started(payload)
+    payload = Payload.init(RunEnvBuilder(env).build())
+    payload = Payload.started(payload)
 
-        payload = payload.push_test_data(successful_test)
+    payload = payload.push_test_data(successful_test)
 
-        result = next(submit(payload))
-        assert result
+    api = API(env)
+    result = next(api.submit(payload))
+    assert result
 
-        assert result.status_code >= 200
-        assert result.status_code < 300
+    assert result.status_code >= 200
+    assert result.status_code < 300
 
-        json = result.json()
-        assert json['upload_id'] == upload_id
+    json = result.json()
+    assert json['upload_id'] == upload_id

--- a/tests/buildkite_test_collector/collector/test_payload.py
+++ b/tests/buildkite_test_collector/collector/test_payload.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from functools import reduce
 
 import pytest


### PR DESCRIPTION
Two parts of this collector need to access environment variables:
- `RunEnv` uses it to discover & construct `run_env` (CI environment details e.g. build message)
- `submit()` uses it to get API key/URL.

Previously we were reaching into `os.environ` throughout the code, and mocking it in tests like this:

```python
with mock.patch.dict(os.environ, {"CI": "true", "BUILDKITE_ANALYTICS_TOKEN": ""}):
```

Now, we wrap those environment accesses behind a `Mapping[str, Optional[str]]` type; real code passes in `os.environ`, and tests pass in an arbitrary dict.

Diff best viewed with whitespace ignored, there's quite a bit of indentation change from removing the `with mock…:` blocks.

Related:
- Stacked on #60 