### PR TITLE
Some small improvements prompted by PyLint errors

### DIFF
--- a/src/buildkite_test_collector/collector/api.py
+++ b/src/buildkite_test_collector/collector/api.py
@@ -8,37 +8,42 @@ from .payload import Payload
 from ..pytest_plugin.logger import logger
 
 
+# pylint: disable=too-few-public-methods
 class API:
     """Buildkite Test Analytics API client"""
 
+    ENV_TOKEN = "BUILDKITE_ANALYTICS_TOKEN"
+    ENV_API_URL = "BUILDKITE_ANALYTICS_API_URL"
+
+    DEFAULT_API_URL = "https://analytics-api.buildkite.com/v1"
+
     def __init__(self, env: Mapping[str, Optional[str]]):
         """Initialize the API client with environment variables"""
-        self.env = env
+        self.token = env.get(self.ENV_TOKEN)
+        self.api_url = env.get(self.ENV_API_URL) or self.DEFAULT_API_URL
 
     def submit(self, payload: Payload, batch_size=100) -> Generator[Optional[Response], Any, Any]:
         """Submit a payload to the API"""
-        token = self.env.get("BUILDKITE_ANALYTICS_TOKEN")
-        api_url = self.env.get("BUILDKITE_ANALYTICS_API_URL") or "https://analytics-api.buildkite.com/v1"
         response = None
 
-        if not token:
-            logger.warning("No `BUILDKITE_ANALYTICS_TOKEN` environment variable present")
+        if not self.token:
+            logger.warning("No %s environment variable present", self.ENV_TOKEN)
             yield None
 
         else:
             for payload_slice in payload.into_batches(batch_size):
                 try:
-                    response = post(api_url + "/uploads",
+                    response = post(self.api_url + "/uploads",
                                     json=payload_slice.as_json(),
                                     headers={
                                         "Content-Type": "application/json",
-                                        "Authorization": f"Token token=\"{token}\""
+                                        "Authorization": f"Token token=\"{self.token}\""
                                     },
                                     timeout=60)
                     response.raise_for_status()
                     yield response
                 except InvalidHeader as error:
-                    logger.warning("Invalid `BUILDKITE_ANALYTICS_TOKEN` environment variable")
+                    logger.warning("Invalid %s environment variable", self.ENV_TOKEN)
                     logger.warning(error)
                     yield None
                 except HTTPError as err:

--- a/src/buildkite_test_collector/collector/run_env.py
+++ b/src/buildkite_test_collector/collector/run_env.py
@@ -6,8 +6,7 @@ from uuid import uuid4
 
 from .constants import COLLECTOR_NAME, VERSION # pylint: disable=W0611
 
-# pylint: disable=R0902
-
+# pylint: disable=too-few-public-methods
 class RunEnvBuilder:
     """Builder class for RunEnv that allows injection of environment variables
 
@@ -116,6 +115,7 @@ class RunEnvBuilder:
         )
 
 
+# pylint: disable=too-many-instance-attributes
 @dataclass(frozen=True)
 class RunEnv:
     """The detected RunEnv"""


### PR DESCRIPTION
PyLint was failing in CI on `main` after my recent changes:

```
************* Module buildkite_test_collector.collector.run_env
src/buildkite_test_collector/collector/run_env.py:11:0: R0903: Too few public methods (1/2) (too-few-public-methods)
************* Module buildkite_test_collector.collector.api
src/buildkite_test_collector/collector/api.py:21:0: C0301: Line too long (105/100) (line-too-long)
src/buildkite_test_collector/collector/api.py:11:0: R0903: Too few public methods (1/2) (too-few-public-methods)
```

I've avoided the long line by pulling out some env var name constants, which is nice anyway.

And I've disabled the very silly `too-few-public-methods` warning on the API and RunEnvBuilder classes. A constructor and one public method should be enough for anyone!