### PR TITLE
Clearer failure/errors in `failure_reason` & `failure_expanded`

### DIFF
--- a/src/buildkite_test_collector/collector/payload.py
+++ b/src/buildkite_test_collector/collector/payload.py
@@ -1,7 +1,7 @@
 """Buildkite Test Analytics payload"""
 
 from dataclasses import dataclass, replace, field
-from typing import Dict, Tuple, Optional, Union, Literal, List
+from typing import Dict, Tuple, Optional, Union, Literal, List, Iterable, Mapping
 from datetime import timedelta
 from uuid import UUID
 
@@ -25,6 +25,7 @@ class TestResultPassed:
 class TestResultFailed:
     """Represents a failed test result"""
     failure_reason: Optional[str]
+    failure_expanded: Optional[Iterable[Mapping[str, Iterable[str]]]] = None
 
 
 @dataclass(frozen=True)
@@ -162,9 +163,10 @@ class TestData:
         """Mark this test as passed"""
         return replace(self, result=TestResultPassed())
 
-    def failed(self, failure_reason=None) -> 'TestData':
+    def failed(self, failure_reason=None, failure_expanded=None) -> 'TestData':
         """Mark this test as failed"""
-        return replace(self, result=TestResultFailed(failure_reason=failure_reason))
+        result = TestResultFailed(failure_reason=failure_reason, failure_expanded=failure_expanded)
+        return replace(self, result=result)
 
     def skipped(self) -> 'TestData':
         """Mark this test as skipped"""
@@ -199,6 +201,8 @@ class TestData:
             attrs["result"] = "failed"
             if self.result.failure_reason is not None:
                 attrs["failure_reason"] = self.result.failure_reason
+            if self.result.failure_expanded is not None:
+                attrs["failure_expanded"] = self.result.failure_expanded
 
         if isinstance(self.result, TestResultSkipped):
             attrs["result"] = "skipped"

--- a/src/buildkite_test_collector/pytest_plugin/failure_reasons.py
+++ b/src/buildkite_test_collector/pytest_plugin/failure_reasons.py
@@ -1,5 +1,6 @@
 """Buildkite Test Engine PyTest failure reason mapping"""
 
+from __future__ import annotations
 from typing import Iterable, Mapping
 
 # importing these privates isn't ideal, but we're only using them for type checking

--- a/src/buildkite_test_collector/pytest_plugin/failure_reasons.py
+++ b/src/buildkite_test_collector/pytest_plugin/failure_reasons.py
@@ -49,8 +49,11 @@ def _handle_string_longrepr(
 ) -> tuple[str | None, Iterable[Mapping[str, Iterable[str]]] | None]:
     """Handle string longrepr case"""
     lines = s.splitlines()
-    failure_reason = lines[0] if lines else s
-    return failure_reason, [{"expanded": lines[1:]}]
+    if len(lines) == 0:
+        return None, None
+    if len(lines) == 1:
+        return lines[0], None
+    return lines[0], [{"expanded": lines[1:]}]
 
 
 def _handle_tuple_longrepr(
@@ -107,9 +110,4 @@ def _handle_default_longrepr(
     longrepr: None | ExceptionInfo[BaseException] | tuple[str, int, str] | str | TerminalRepr
 ) -> tuple[str | None, Iterable[Mapping[str, Iterable[str]]] | None]:
     """Handle default longrepr case"""
-    lines = str(longrepr).splitlines()
-    if len(lines) == 0:
-        return None, None
-    if len(lines) == 1:
-        return lines[0], None
-    return lines[0], [{"expanded": lines[1:]}]
+    return _handle_string_longrepr(str(longrepr))

--- a/src/buildkite_test_collector/pytest_plugin/failure_reasons.py
+++ b/src/buildkite_test_collector/pytest_plugin/failure_reasons.py
@@ -1,0 +1,76 @@
+"""Buildkite Test Engine PyTest failure reason mapping"""
+
+from typing import Iterable, Mapping
+
+# importing these privates isn't ideal, but we're only using them for type checking
+from _pytest._code.code import ExceptionInfo, ExceptionRepr, TerminalRepr
+
+# pylint: disable=too-many-locals
+# pylint: disable=too-many-return-statements
+def failure_reasons(
+    longrepr: None | ExceptionInfo[BaseException] | tuple[str, int, str] | str | TerminalRepr
+) -> tuple[str | None, Iterable[Mapping[str, Iterable[str]]] | None]:
+    """
+    Derives Buildkite's failure_reason & failure_expanded from PyTest's longrepr.
+
+    Args:
+        longrepr: The PyTest longrepr object containing failure information
+
+    Returns:
+        A tuple containing:
+        - A string with the failure reason or None if not available
+        - A list of mappings with additional failure details or None if not available
+    """
+    match longrepr:
+        case None:
+            return None, None
+
+        case str() as s:
+            lines = s.splitlines()
+            failure_reason = lines[0] if lines else s
+            return failure_reason, [{"expanded": lines[1:]}]
+
+        case (path, line, msg)  if \
+                isinstance(path, str) and isinstance(line, int) and isinstance(msg, str):
+            failure_reason = msg
+            return failure_reason, [{"expanded": [], "backtrace": [f"{path}:{line}"]}]
+
+        case ExceptionInfo() as exc_info:
+            failure_reason = exc_info.exconly()
+            expanded = []
+            backtrace = []
+
+            if hasattr(exc_info, "traceback") and exc_info.traceback:
+                for entry in exc_info.traceback:
+                    backtrace.append(f"{entry.path}:{entry.lineno}: {entry.name}")
+                    source = entry.getsource() if hasattr(entry, "getsource") else None
+                    if source:
+                        expanded.extend(str(line) for line in source)
+
+            failure_expanded = {}
+            if len(expanded) > 0:
+                failure_expanded["expanded"] = expanded
+            if len(backtrace) > 0:
+                failure_expanded["backtrace"] = backtrace
+
+            return failure_reason, [failure_expanded]
+
+        case ExceptionRepr() as er if er.reprcrash is not None:
+            failure_reason = er.reprcrash.message # e.g. "ZeroDivisionError: division by zero"
+            failure_expanded = [{"expanded": str(er).splitlines()}]
+            try:
+                failure_expanded[0]["backtrace"] = [
+                    str(getattr(entry, 'reprfileloc', entry))
+                    for entry in er.reprtraceback.reprentries
+                ]
+            except AttributeError:
+                pass
+            return failure_reason, failure_expanded
+
+        case _:
+            lines = str(longrepr).splitlines()
+            if len(lines) == 0:
+                return None, None
+            if len(lines) == 1:
+                return lines[0], None
+            return lines[0], [{"expanded": lines[1:]}]

--- a/tests/buildkite_test_collector/collector/test_payload.py
+++ b/tests/buildkite_test_collector/collector/test_payload.py
@@ -161,7 +161,8 @@ def test_test_data_as_json_when_failed(failed_test):
     json = failed_test.as_json(Instant.now())
 
     assert json["result"] == "failed"
-    assert json["failure_reason"] == failed_test.result.failure_reason
+    assert json["failure_reason"] == "bogus"
+    assert json["failure_expanded"] == [{'expanded': ['test failed'], 'backtrace': ['test.py:1']}]
 
 
 def test_test_data_as_json_when_skipped(skipped_test):

--- a/tests/buildkite_test_collector/conftest.py
+++ b/tests/buildkite_test_collector/conftest.py
@@ -26,7 +26,10 @@ def successful_test(history_finished) -> TestData:
 
 @pytest.fixture
 def failed_test(successful_test) -> TestData:
-    return replace(successful_test, result=TestResultFailed("bogus"))
+    return replace(
+        successful_test,
+        result=TestResultFailed("bogus", [{"expanded": ["test failed"], "backtrace": ["test.py:1"]}])
+    )
 
 
 @pytest.fixture

--- a/tests/buildkite_test_collector/pytest_plugin/test_plugin.py
+++ b/tests/buildkite_test_collector/pytest_plugin/test_plugin.py
@@ -1,9 +1,11 @@
 import json
 import pytest
 
-from buildkite_test_collector.collector.payload import Payload
+from buildkite_test_collector.collector.payload import Payload, TestData, TestResultFailed, TestResultPassed, TestResultSkipped
 from buildkite_test_collector.pytest_plugin import BuildkitePlugin
 
+from _pytest._code.code import ExceptionInfo
+from _pytest.reports import TestReport
 
 def test_runtest_logstart_with_unstarted_payload(fake_env):
     payload = Payload.init(fake_env)
@@ -14,6 +16,122 @@ def test_runtest_logstart_with_unstarted_payload(fake_env):
     plugin.pytest_runtest_logstart("wat::when", [1, 2])
 
     assert plugin.payload.started_at is not None
+
+
+def test_pytest_runtest_logreport_simple_pass(fake_env):
+    payload = Payload.init(fake_env)
+    plugin = BuildkitePlugin(payload)
+
+    location = ("", None, "")
+    report = TestReport(nodeid="", location=location, keywords={}, outcome="passed", longrepr=None, when="call")
+
+    plugin.pytest_runtest_logstart(report.nodeid, location)
+    plugin.pytest_runtest_logreport(report)
+
+    test_data = plugin.in_flight.get(report.nodeid)
+    assert test_data is not None
+
+    assert isinstance(test_data.result, TestResultPassed)
+
+
+def test_pytest_runtest_logreport_fail_oneline(fake_env):
+    payload = Payload.init(fake_env)
+    plugin = BuildkitePlugin(payload)
+
+    location = ("", None, "")
+    longrepr = "the reason the test failed"
+    report = TestReport(nodeid="", location=location, keywords={}, outcome="failed", longrepr=longrepr, when="call")
+
+    plugin.pytest_runtest_logstart(report.nodeid, location)
+    plugin.pytest_runtest_logreport(report)
+    test_data = plugin.in_flight.get(report.nodeid)
+    plugin.pytest_runtest_logfinish(report.nodeid, location)
+
+    assert isinstance(test_data, TestData)
+    assert isinstance(test_data.result, TestResultFailed)
+    assert test_data.result.failure_reason == "the reason the test failed"
+
+
+def test_pytest_runtest_logreport_fail_multiline(fake_env):
+    payload = Payload.init(fake_env)
+    plugin = BuildkitePlugin(payload)
+
+    location = ("", None, "")
+    longrepr = "the reason the test failed\n.. is quite complicated\nso here is more detail"
+    report = TestReport(nodeid="", location=location, keywords={}, outcome="failed", longrepr=longrepr, when="call")
+
+    plugin.pytest_runtest_logstart(report.nodeid, location)
+    plugin.pytest_runtest_logreport(report)
+    test_data = plugin.in_flight.get(report.nodeid)
+    plugin.pytest_runtest_logfinish(report.nodeid, location)
+
+    assert isinstance(test_data, TestData)
+    assert isinstance(test_data.result, TestResultFailed)
+    assert test_data.result.failure_reason == "the reason the test failed"
+    assert test_data.result.failure_expanded == [{"expanded": [".. is quite complicated", "so here is more detail"]}]
+
+
+def test_pytest_runtest_logreport_fail_exception(fake_env):
+    payload = Payload.init(fake_env)
+    plugin = BuildkitePlugin(payload)
+
+    location = ("", None, "")
+    try:
+        raise Exception("a fake exception for testing")
+    except Exception as e:
+        longrepr = ExceptionInfo.from_exception(e)
+    report = TestReport(nodeid="", location=location, keywords={}, outcome="failed", longrepr=longrepr, when="call")
+
+    plugin.pytest_runtest_logstart(report.nodeid, location)
+    plugin.pytest_runtest_logreport(report)
+    test_data = plugin.in_flight.get(report.nodeid)
+    plugin.pytest_runtest_logfinish(report.nodeid, location)
+
+    assert isinstance(test_data, TestData)
+    assert isinstance(test_data.result, TestResultFailed)
+    assert test_data.result.failure_reason == "Exception: a fake exception for testing"
+
+    assert isinstance(test_data.result.failure_expanded, list)
+    fe = test_data.result.failure_expanded[0]
+    assert list(fe.keys()) == ["expanded", "backtrace"]
+    assert isinstance(fe["expanded"], list)
+    assert len(fe["expanded"]) > 0
+    assert isinstance(fe["backtrace"], list)
+    assert len(fe["backtrace"]) > 0
+
+
+def test_pytest_runtest_logreport_simple_fail(fake_env):
+    payload = Payload.init(fake_env)
+    plugin = BuildkitePlugin(payload)
+
+    location = ("", None, "")
+    report = TestReport(nodeid="", location=location, keywords={}, outcome="failed", longrepr=None, when="call")
+
+    plugin.pytest_runtest_logstart(report.nodeid, location)
+    plugin.pytest_runtest_logreport(report)
+
+    test_data = plugin.in_flight.get(report.nodeid)
+    assert test_data is not None
+
+    assert isinstance(test_data.result, TestResultFailed)
+
+
+def test_pytest_runtest_logreport_simple_skip(fake_env):
+    payload = Payload.init(fake_env)
+    plugin = BuildkitePlugin(payload)
+
+    location = ("path/to/test.py", 100, "")
+    longrepr = ("path/to/test.py", 123, "skippy")
+    report = TestReport(nodeid="", location=location, keywords={}, outcome="skipped", longrepr=longrepr, when="call")
+
+    plugin.pytest_runtest_logstart(report.nodeid, location)
+    plugin.pytest_runtest_logreport(report)
+
+    test_data = plugin.in_flight.get(report.nodeid)
+    assert isinstance(test_data, TestData)
+
+    assert isinstance(test_data.result, TestResultSkipped)
+    # TODO: track skip reason as failure_reason via longrepr
 
 
 def test_save_json_payload_without_merge(fake_env, tmp_path, successful_test):


### PR DESCRIPTION
Currently, the entire failure from PyTest (PyTest calls it `longreprtext`) is set as `failure_reason`.

However, `failure_reason` is intended for a short one-line summary, and gets truncated to ~1KIB, which isn't great for `longreprtext`.

Buildkite also supports `failure_expanded`, for including detailed information and backtraces on errors.

So, derive that from the various shapes that `longrepr` can take, and include them in the uploaded JSON payload.

| Before | After |
|--------|--------|
| Unclear `failure_reason` summaries:<br> <img width="981" height="278" alt="image" src="https://github.com/user-attachments/assets/d7df9ecf-2581-4135-ad7b-f76c55066dbc" /> | Useful failure/error messages:<br> <img width="967" height="273" alt="image" src="https://github.com/user-attachments/assets/08d5562c-7e39-48ef-9ad1-2745c2984dbe" /> |
| Truncated unclear expanded text which doesn't even mention the ZeroDivisionError:<br> <img width="964" height="748" alt="image" src="https://github.com/user-attachments/assets/58ec84b0-035e-46c6-b818-76908c0547f5" /> | Full expanded information and stack trace:<br> <img width="969" height="1291" alt="image" src="https://github.com/user-attachments/assets/45dd32f4-cbf0-47fd-b63f-fe40c5390581" /> | 