### PR TITLE
`collector.VERSION` constant from `pyproject.toml` via `importlib.metadata`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/buildk
 
 ## 🚀 Releasing
 
-1. Open a new PR bumping the version number in `constants.py`, make sure the PR title contains `[release]`.
+1. Open a new PR bumping the version number in `pyproject.toml`, make sure the PR title contains `[release]`.
 2. Get the PR approved and merged, this will trigger the release pipeline.
 3. (Optional) In the event of step 3 failure, run `.buildkite/steps/release-pypi` locally with your own credentials.
 4. Create a [new github release](https://github.com/buildkite/test-collector-python/releases) for prosperity, you can create a tag as you create the release.

--- a/src/buildkite_test_collector/collector/constants.py
+++ b/src/buildkite_test_collector/collector/constants.py
@@ -2,5 +2,16 @@
 
 """This module defines collector-level constants."""
 
-COLLECTOR_NAME='buildkite-test-collector'
-VERSION='1.0.4'
+DISTRIBUTION_NAME = 'buildkite-test-collector'
+COLLECTOR_NAME = f"python-{DISTRIBUTION_NAME}"
+
+try:
+    from importlib.metadata import version, PackageNotFoundError
+    try:
+        VERSION = version(DISTRIBUTION_NAME)
+    except PackageNotFoundError:
+        # Fallback for development environments where package isn't installed
+        VERSION = 'dev'
+except ImportError:
+    # Fallback for edge cases
+    VERSION = 'unknown'

--- a/src/buildkite_test_collector/collector/run_env.py
+++ b/src/buildkite_test_collector/collector/run_env.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Dict, Optional, Mapping
 from uuid import uuid4
 
-from .constants import COLLECTOR_NAME, VERSION # pylint: disable=W0611
+from .constants import COLLECTOR_NAME, VERSION
 
 # pylint: disable=too-few-public-methods
 class RunEnvBuilder:
@@ -140,7 +140,7 @@ class RunEnv:
             "commit_sha": self.commit_sha,
             "message": self.message,
             "url": self.url,
-            "collector": f"python-{COLLECTOR_NAME}",
+            "collector": COLLECTOR_NAME,
             "version": VERSION,
             "language_version": f"{platform.python_version()}"
         }

--- a/tests/buildkite_test_collector/collector/test_run_env.py
+++ b/tests/buildkite_test_collector/collector/test_run_env.py
@@ -3,7 +3,7 @@ from random import randint
 from uuid import uuid4, UUID
 
 from buildkite_test_collector.collector.constants import VERSION
-from buildkite_test_collector.collector.run_env import RunEnv, RunEnvBuilder
+from buildkite_test_collector.collector.run_env import RunEnvBuilder
 
 
 def test_detect_env_with_buildkite_api_env_vars_returns_the_correct_environment():


### PR DESCRIPTION
There should be a single source of truth for the version.

Prior to uv (#58) the `setup.py` file was loading the version attribute from the `collector.VERSION` constant... but `pyproject.toml` can't do that, so now we're doing it the other way around.

```
test-collector-python $ PYTHONPATH=src python -c 'from buildkite_test_collector.collector.constants import VERSION; print(VERSION)'
1.0.4
```

👌🏼