### PR TITLE
[release] v1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "buildkite-test-collector"
-version = "1.0.4"
+version = "1.1.0"
 description = "Buildkite Test Engine collector"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/uv.lock
+++ b/uv.lock
@@ -46,7 +46,7 @@ wheels = [
 
 [[package]]
 name = "buildkite-test-collector"
-version = "1.0.4"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },
@@ -291,7 +291,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [


### PR DESCRIPTION
## Fixes

* Clearer failure/errors in `failure_reason` & `failure_expanded` by @pda in https://github.com/buildkite/test-collector-python/pull/64
* Handle failure in `setup` eg fixtures by @pda in https://github.com/buildkite/test-collector-python/pull/65
* Add 'language_version' attribute to env var by @gchan in https://github.com/buildkite/test-collector-python/pull/67

## Changes

* uv by @pda in https://github.com/buildkite/test-collector-python/pull/58
* Abstract `os.environ` so real env doesn't interfere with tests by @pda in https://github.com/buildkite/test-collector-python/pull/61
* Unused `.devcontainer/*` removed by @pda in https://github.com/buildkite/test-collector-python/pull/59
* Rename `RuntimeEnvironment` to `RunEnv` by @pda in https://github.com/buildkite/test-collector-python/pull/60
* Some small improvements prompted by PyLint errors by @pda in https://github.com/buildkite/test-collector-python/pull/62
* `s/Test Analytics/Test Engine/g` by @pda in https://github.com/buildkite/test-collector-python/pull/63
* Python 3.8 no longer supported; EOL was 2024-10-07 by @pda in https://github.com/buildkite/test-collector-python/pull/66