### PR TITLE
Don't run if CI isn't set

### DIFF
--- a/src/buildkite_test_collector/collector/api.py
+++ b/src/buildkite_test_collector/collector/api.py
@@ -12,6 +12,8 @@ from ..pytest_plugin.logger import logger
 class API:
     """Buildkite Test Engine API client"""
 
+    CI_TOKEN = "CI"
+
     ENV_TOKEN = "BUILDKITE_ANALYTICS_TOKEN"
     ENV_API_URL = "BUILDKITE_ANALYTICS_API_URL"
 
@@ -19,12 +21,16 @@ class API:
 
     def __init__(self, env: Mapping[str, Optional[str]]):
         """Initialize the API client with environment variables"""
+        self.ci = env.get(self.CI_TOKEN)
         self.token = env.get(self.ENV_TOKEN)
         self.api_url = env.get(self.ENV_API_URL) or self.DEFAULT_API_URL
 
     def submit(self, payload: Payload, batch_size=100) -> Generator[Optional[Response], Any, Any]:
         """Submit a payload to the API"""
         response = None
+
+        if not self.ci:
+            yield None
 
         if not self.token:
             logger.warning("No %s environment variable present", self.ENV_TOKEN)

--- a/tests/buildkite_test_collector/collector/test_api.py
+++ b/tests/buildkite_test_collector/collector/test_api.py
@@ -11,21 +11,36 @@ from buildkite_test_collector.collector.api import API
 from buildkite_test_collector.collector.payload import Payload
 from requests.exceptions import ReadTimeout, ConnectTimeout
 
+def test_submit_local_returns_none(capfd):
+    env = {"CI": None}
+    payload = Payload.init(RunEnvBuilder(env).build())
 
-def test_submit_with_missing_api_key_environment_variable_returns_none():
+    api = API(env)
+    assert next(api.submit(payload)) is None
+    captured = capfd.readouterr()
+
+    assert not captured.err.startswith("buildkite-test-collector - WARNING -")
+
+def test_submit_with_missing_api_key_environment_variable_returns_none(capfd):
     env = {"CI": "true", "BUILDKITE_ANALYTICS_TOKEN": None}
     payload = Payload.init(RunEnvBuilder(env).build())
 
     api = API(env)
     assert next(api.submit(payload)) is None
+    captured = capfd.readouterr()
+
+    assert captured.err.startswith("buildkite-test-collector - WARNING -")
 
 
-def test_submit_with_invalid_api_key_environment_variable_returns_none():
+def test_submit_with_invalid_api_key_environment_variable_returns_none(capfd):
     env = {"CI": "true", "BUILDKITE_ANALYTICS_TOKEN": "\n"}
     payload = Payload.init(RunEnvBuilder(env).build())
 
     api = API(env)
     assert next(api.submit(payload)) is None
+    captured = capfd.readouterr()
+
+    assert captured.err.startswith("buildkite-test-collector - WARNING -")
 
 @responses.activate
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")


### PR DESCRIPTION
This should quiet these warnings when running pytest locally on developer machines outside of CI:

```
buildkite-test-collector - WARNING - No BUILDKITE_ANALYTICS_TOKEN environment variable present
```

Based on the README, I think this was already the intent:

> Run your tests like normal. Note that we attempt to detect the presence of several common CI environments, however if this fails you can set the `CI` environment variable to any value and it will work.