### PR TITLE
Fix tests skipped during setup phase reporting with no result

### DIFF
--- a/src/buildkite_test_collector/pytest_plugin/buildkite_plugin.py
+++ b/src/buildkite_test_collector/pytest_plugin/buildkite_plugin.py
@@ -106,14 +106,26 @@ class BuildkitePlugin:
                 logger.debug("-> subtest passed/skipped, ignoring")
             return
 
-        # This hook is called three times during the lifecycle of a test:
-        # after the setup phase, the call phase, and the teardown phase.
-        # We capture outcomes from the call phase, or setup/teardown phase if it failed
-        # (since setup failures prevent the call phase from running, and teardown
-        # failures should mark an otherwise passing test as failed).
+        # This hook fires three times per test: setup, call, teardown.
+        # We only capture the result when it carries meaningful information:
+        #
+        #   call:     always — this is the actual test result.
+        #   setup:    only on failure or skip — the call phase won't run,
+        #             so this is the only outcome we'll get.
+        #   teardown: only on failure — overrides the call result because
+        #             broken cleanup should fail the test.
+        #
+        # We intentionally skip setup-passed and teardown-passed/skipped
+        # because they would overwrite the real test outcome.
+        #
         # See: https://github.com/buildkite/test-collector-python/pull/45
         # See: https://github.com/buildkite/test-collector-python/issues/84
-        if report.when == 'call' or (report.when in ('setup', 'teardown') and report.failed):
+        should_capture = (
+            report.when == 'call'
+            or (report.when == 'setup' and not report.passed)
+            or (report.when == 'teardown' and report.failed)
+        )
+        if should_capture:
             # Guard: do not let the parent test's "passed" call-phase
             # report overwrite a failure that was set by a SubtestReport.
             if (

--- a/tests/buildkite_test_collector/pytest_plugin/test_plugin.py
+++ b/tests/buildkite_test_collector/pytest_plugin/test_plugin.py
@@ -196,6 +196,23 @@ def test_pytest_runtest_logreport_simple_skip(fake_env):
     # TODO: track skip reason as failure_reason via longrepr
 
 
+def test_pytest_runtest_logreport_skip_in_setup(fake_env):
+    """Tests skipped during setup (e.g. @pytest.mark.skip) should be recorded as skipped"""
+    payload = Payload.init(fake_env)
+    plugin = BuildkitePlugin(payload)
+
+    location = ("path/to/test.py", 100, "")
+    longrepr = ("path/to/test.py", 100, "Skipped: unconditional skip")
+    report = TestReport(nodeid="", location=location, keywords={}, outcome="skipped", longrepr=longrepr, when="setup")
+
+    plugin.pytest_runtest_logstart(report.nodeid, location)
+    plugin.pytest_runtest_logreport(report)
+
+    test_data = plugin.in_flight.get(report.nodeid)
+    assert isinstance(test_data, TestData)
+    assert isinstance(test_data.result, TestResultSkipped)
+
+
 def test_save_json_payload_without_merge(fake_env, tmp_path, successful_test):
     payload = Payload.init(fake_env)
     payload = Payload.started(payload)


### PR DESCRIPTION
## Context

This was originally reported as a [test-engine-client issue](https://github.com/buildkite/test-engine-client/issues/464) where `OnlyMutedFailures()` returns false due to unrecognized test statuses. I traced the root cause back to the test collector itself.

When a test is skipped during the setup phase (e.g. via `@pytest.mark.skip`, `@pytest.mark.skipif`, or `pytest.skip()` in a fixture), the call phase never runs. The `pytest_runtest_logreport` hook fires with `report.when="setup"` and `report.outcome="skipped"`, but the existing condition only captured **setup failures**, not **setup skips**:

```python
# before
if report.when == 'call' or (report.when in ('setup', 'teardown') and report.failed):
```

This meant `update_test_result` was never called, so the test's `result` stayed `None`. When serialized to JSON, the `result` key was omitted entirely. The test-engine-client then treated this as `"unknown"`, which broke the status accounting in `RunResult.Status()` and caused `OnlyMutedFailures()` to return false.

## Changes

- Added setup-skipped tests to the capture condition so they are correctly recorded as `"skipped"` in the JSON payload, with a corresponding unit test.

## Test plan

- [x] New unit test `test_pytest_runtest_logreport_skip_in_setup` passes
- [x] Full test suite (92 tests) passes
- [x] Run pytest with the `--json` option on a test suite that includes `@pytest.mark.skip` tests and verify the JSON output contains `"result": "skipped"` for those tests