### PR TITLE
Add defensive handling for missing test results

### DIFF
--- a/src/buildkite_test_collector/collector/payload.py
+++ b/src/buildkite_test_collector/collector/payload.py
@@ -244,8 +244,7 @@ class TestData:
         elif isinstance(self.result, TestResultSkipped):
             attrs["result"] = "skipped"
         else:
-            logger.warning("Test %s has no result set, defaulting to unknown", self.name)
-            attrs["result"] = "unknown"
+            logger.warning("Test %s has no result set, omitting result key", self.name)
 
         return attrs
 

--- a/src/buildkite_test_collector/collector/payload.py
+++ b/src/buildkite_test_collector/collector/payload.py
@@ -235,16 +235,17 @@ class TestData:
 
         if isinstance(self.result, TestResultPassed):
             attrs["result"] = "passed"
-
-        if isinstance(self.result, TestResultFailed):
+        elif isinstance(self.result, TestResultFailed):
             attrs["result"] = "failed"
             if self.result.failure_reason is not None:
                 attrs["failure_reason"] = self.result.failure_reason
             if self.result.failure_expanded is not None:
                 attrs["failure_expanded"] = self.result.failure_expanded
-
-        if isinstance(self.result, TestResultSkipped):
+        elif isinstance(self.result, TestResultSkipped):
             attrs["result"] = "skipped"
+        else:
+            logger.warning("Test %s has no result set, defaulting to unknown", self.name)
+            attrs["result"] = "unknown"
 
         return attrs
 

--- a/src/buildkite_test_collector/pytest_plugin/buildkite_plugin.py
+++ b/src/buildkite_test_collector/pytest_plugin/buildkite_plugin.py
@@ -188,16 +188,14 @@ class BuildkitePlugin:
             if report.passed:
                 logger.debug('-> test passed')
                 test_data = test_data.passed()
-
-            if report.failed:
+            elif report.failed:
                 failure_reason, failure_expanded = failure_reasons(longrepr=report.longrepr)
                 logger.debug('-> test failed: %s', failure_reason)
                 test_data = test_data.failed(
                     failure_reason=failure_reason,
                     failure_expanded=failure_expanded
                 )
-
-            if report.skipped:
+            elif report.skipped:
                 logger.debug('-> test skipped')
                 test_data = test_data.skipped()
 
@@ -215,6 +213,8 @@ class BuildkitePlugin:
             logger.debug('-> finalize_test: not in flight: %s', nodeid)
             return False
         del self.in_flight[nodeid]
+        if test_data.result is None:
+            logger.warning('Test %s has no result set at finalization', nodeid)
         test_data = test_data.finish()
         logger.debug('-> finalize_test nodeid=%s duration=%s', nodeid, test_data.history.duration)
         self.payload = self.payload.push_test_data(test_data)

--- a/tests/buildkite_test_collector/data/test_sample_skip.py
+++ b/tests/buildkite_test_collector/data/test_sample_skip.py
@@ -1,0 +1,40 @@
+"""Sample test file used by the integration test.
+
+This file exercises various skip mechanisms and is run in a subprocess
+by test_integration_skip.py to verify the JSON output contains
+"result": "skipped" for each case.
+"""
+
+import pytest
+
+
+@pytest.mark.skip(reason="unconditional skip")
+def test_skip_marker():
+    """Skipped via @pytest.mark.skip — skip happens during setup."""
+    assert False  # noqa: B011 -- should never run
+
+
+@pytest.mark.skipif(True, reason="condition is true")
+def test_skipif_marker():
+    """Skipped via @pytest.mark.skipif — skip happens during setup."""
+    assert False  # noqa: B011 -- should never run
+
+
+@pytest.fixture
+def skip_fixture():
+    pytest.skip("skipped in fixture")
+
+
+def test_skip_in_fixture(skip_fixture):
+    """Skipped via pytest.skip() inside a fixture — skip happens during setup."""
+    assert False  # noqa: B011 -- should never run
+
+
+def test_skip_inline():
+    """Skipped via pytest.skip() in the test body — skip happens during call."""
+    pytest.skip("inline skip")
+
+
+def test_passing():
+    """A normal passing test to verify we don't break non-skipped tests."""
+    assert True

--- a/tests/buildkite_test_collector/test_integration_skip.py
+++ b/tests/buildkite_test_collector/test_integration_skip.py
@@ -1,0 +1,111 @@
+"""Integration test: run a real pytest subprocess with skipped tests and verify JSON output.
+
+This exercises the fix for tests skipped during the setup phase (e.g.
+@pytest.mark.skip, @pytest.mark.skipif, pytest.skip() in fixtures)
+which previously produced JSON with no "result" key.
+
+See: https://github.com/buildkite/test-engine-client/issues/464
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SAMPLE_FILE = Path(__file__).parent / "data" / "test_sample_skip.py"
+
+
+class TestSkipIntegration:
+    """End-to-end: pytest subprocess -> collector -> JSON file -> assertions."""
+
+    def _run_pytest(self, tmp_path, *extra_args):
+        json_output = tmp_path / "results.json"
+        cmd = [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(SAMPLE_FILE),
+            f"--json={json_output}",
+            "-v",
+            *extra_args,
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        return result, json_output
+
+    def test_all_tests_have_result_key(self, tmp_path):
+        """Every test in the JSON output must have a 'result' key."""
+        result, json_output = self._run_pytest(tmp_path)
+
+        assert json_output.exists(), f"JSON not created. stderr:\n{result.stderr}"
+        data = json.loads(json_output.read_text())
+
+        for entry in data:
+            assert "result" in entry, (
+                f"Test {entry['name']} is missing the 'result' key — "
+                "this causes test-engine-client to treat it as unknown."
+            )
+
+    def test_skip_marker_reported_as_skipped(self, tmp_path):
+        """@pytest.mark.skip produces 'result': 'skipped'."""
+        result, json_output = self._run_pytest(tmp_path, "-k", "test_skip_marker")
+
+        data = json.loads(json_output.read_text())
+        tests_by_name = {t["name"]: t for t in data}
+
+        assert tests_by_name["test_skip_marker"]["result"] == "skipped"
+
+    def test_skipif_marker_reported_as_skipped(self, tmp_path):
+        """@pytest.mark.skipif produces 'result': 'skipped'."""
+        result, json_output = self._run_pytest(tmp_path, "-k", "test_skipif_marker")
+
+        data = json.loads(json_output.read_text())
+        tests_by_name = {t["name"]: t for t in data}
+
+        assert tests_by_name["test_skipif_marker"]["result"] == "skipped"
+
+    def test_skip_in_fixture_reported_as_skipped(self, tmp_path):
+        """pytest.skip() in a fixture produces 'result': 'skipped'."""
+        result, json_output = self._run_pytest(tmp_path, "-k", "test_skip_in_fixture")
+
+        data = json.loads(json_output.read_text())
+        tests_by_name = {t["name"]: t for t in data}
+
+        assert tests_by_name["test_skip_in_fixture"]["result"] == "skipped"
+
+    def test_skip_inline_reported_as_skipped(self, tmp_path):
+        """pytest.skip() in the test body produces 'result': 'skipped'."""
+        result, json_output = self._run_pytest(tmp_path, "-k", "test_skip_inline")
+
+        data = json.loads(json_output.read_text())
+        tests_by_name = {t["name"]: t for t in data}
+
+        assert tests_by_name["test_skip_inline"]["result"] == "skipped"
+
+    def test_passing_test_unaffected(self, tmp_path):
+        """A normal passing test still works."""
+        result, json_output = self._run_pytest(tmp_path, "-k", "test_passing")
+
+        data = json.loads(json_output.read_text())
+        tests_by_name = {t["name"]: t for t in data}
+
+        assert tests_by_name["test_passing"]["result"] == "passed"
+
+    def test_full_run_correct_results(self, tmp_path):
+        """Run all sample tests. Verify counts and per-test results."""
+        result, json_output = self._run_pytest(tmp_path)
+
+        data = json.loads(json_output.read_text())
+        tests_by_name = {t["name"]: t for t in data}
+
+        assert len(data) == 5, (
+            f"Expected 5 entries, got {len(data)}: {list(tests_by_name.keys())}"
+        )
+
+        assert tests_by_name["test_skip_marker"]["result"] == "skipped"
+        assert tests_by_name["test_skipif_marker"]["result"] == "skipped"
+        assert tests_by_name["test_skip_in_fixture"]["result"] == "skipped"
+        assert tests_by_name["test_skip_inline"]["result"] == "skipped"
+        assert tests_by_name["test_passing"]["result"] == "passed"


### PR DESCRIPTION
## Context

Follow-up to #102. While reviewing the setup-skip fix, I identified a few additional hardening opportunities that prevent the same class of bug (`result=None` → missing `"result"` key → test-engine-client treats it as unknown) from resurfacing through other code paths.

See: https://github.com/buildkite/test-engine-client/issues/464

## Changes

**Warning logs for unset results** — Both `as_json()` and `finalize_test()` now log a warning when a test has no result set. This makes any future `result=None` bug immediately visible in logs instead of silently producing bad JSON. We intentionally do *not* emit a default `"result"` value — test-engine-client treats any unrecognized value the same as a missing key, so a default wouldn't help downstream.

**`if`/`elif` in `update_test_result()` and `as_json()`** — Changed independent `if` statements to `if`/`elif`/`elif` to make the mutual exclusivity of pytest outcomes (`passed`, `failed`, `skipped`) and result types explicit.

**Integration tests for skip scenarios** — Subprocess-based tests covering `@pytest.mark.skip`, `@pytest.mark.skipif`, `pytest.skip()` in fixtures, and `pytest.skip()` in the test body. Verifies the actual JSON output contains `"result": "skipped"` end-to-end.

## Note on test-engine-client hardening

The root cause of [#464](https://github.com/buildkite/test-engine-client/issues/464) is that `RunResult.Status()` lets a single test with an unrecognized status poison the entire run — the `passed + skipped + failedMuted == len(r.tests)` check fails and falls through to `RunStatusUnknown`. A more defensive pattern would be to either:
- Exclude tests with unrecognized statuses from the total count
- Treat missing/unrecognized results as `"skipped"` (the least harmful default)
- At minimum, log which tests had unrecognized statuses so the source collector can be debugged

This would prevent any future collector bug in any language from breaking `OnlyMutedFailures()`.

## Test plan

- [x] All 99 tests pass (existing + new integration tests)
- [x] New integration tests cover all four skip mechanisms
- [x] `test_all_tests_have_result_key` asserts every test entry in JSON has a `result` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)