### PR TITLE
[release] version 1.4.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "buildkite-test-collector"
-version = "1.4.2"
+version = "1.4.3"
 description = "Buildkite Test Engine collector"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Description

Bump version to 1.4.3 for release.

## Changes since v1.4.2

- Capture collection errors (e.g. import failures) in JSON report (#108) — adds a `pytest_collectreport` hook to `BuildkitePlugin` so collection-phase errors (import failures, syntax errors, etc.) are captured as failed `TestData` entries tagged with `test.collection_error=true`. Previously, when a test file failed to import, pytest failed during collection and the error was silently dropped from the report — combined with pytest-xdist and bktec retries this could cause builds to report green when a test file failed to collect.

### Full changes
https://github.com/buildkite/test-collector-python/compare/v1.4.2...main

## Verification

All tests pass (`uv run pytest`): 103 passed, 5 skipped.

## Deployment

Low risk patch release. The Buildkite release pipeline will automatically publish to PyPI after merge.