### PR TITLE
Send test_runner from pytest collector

### DIFF
--- a/src/buildkite_test_collector/collector/constants.py
+++ b/src/buildkite_test_collector/collector/constants.py
@@ -4,6 +4,7 @@
 
 DISTRIBUTION_NAME = 'buildkite-test-collector'
 COLLECTOR_NAME = f"python-{DISTRIBUTION_NAME}"
+TEST_RUNNER = "pytest"
 
 try:
     from importlib.metadata import version, PackageNotFoundError

--- a/src/buildkite_test_collector/collector/run_env.py
+++ b/src/buildkite_test_collector/collector/run_env.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Dict, Optional, Mapping
 from uuid import uuid4
 
-from .constants import COLLECTOR_NAME, VERSION
+from .constants import COLLECTOR_NAME, VERSION, TEST_RUNNER
 
 # pylint: disable=too-few-public-methods
 class RunEnvBuilder:
@@ -141,6 +141,7 @@ class RunEnv:
             "message": self.message,
             "url": self.url,
             "collector": COLLECTOR_NAME,
+            "test_runner": TEST_RUNNER,
             "version": VERSION,
             "language_version": f"{platform.python_version()}"
         }

--- a/tests/buildkite_test_collector/collector/test_payload.py
+++ b/tests/buildkite_test_collector/collector/test_payload.py
@@ -62,6 +62,7 @@ def test_payload_as_json(payload, successful_test):
 
     assert json["format"] == "json"
     assert json["run_env"]["key"] == payload.run_env.key
+    assert json["run_env"]["test_runner"] == "pytest"
     assert json["data"][0]["id"] == str(successful_test.id)
 
 

--- a/tests/buildkite_test_collector/collector/test_run_env.py
+++ b/tests/buildkite_test_collector/collector/test_run_env.py
@@ -105,3 +105,4 @@ def test_env_as_json(fake_env):
     assert json["version"] == VERSION
     expected_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
     assert json["language_version"] == expected_version
+    assert json["test_runner"] == "pytest"


### PR DESCRIPTION
We're adding a `test.selector.primary` tag on ingestion that `bktec` uses to split tests. The value of `test.selector.primary` is different for each test runner, so ingestion needs to know which runner produced the upload before it can set that tag. Right now the pytest collector doesn't tell ingestion what runner it is.

To fix that, the collector now sends `test_runner` as part of `run_env` when it uploads to the Upload API. The value is always `pytest` for this collector.

Once this ships, ingestion can read `run_env.test_runner` and decide how to set `test.selector.primary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)