### PR TITLE
Normalize pytest file paths to process cwd for test.selector.primary inference

### DIFF
--- a/src/buildkite_test_collector/pytest_plugin/__init__.py
+++ b/src/buildkite_test_collector/pytest_plugin/__init__.py
@@ -29,7 +29,7 @@ def pytest_configure(config):
         "add tag to test execution for Buildkite Test Collector. "
         "Both key and value must be a string.")
 
-    plugin = BuildkitePlugin(Payload.init(env))
+    plugin = BuildkitePlugin(Payload.init(env), rootpath=config.rootpath)
     setattr(config, '_buildkite', plugin)
     config.pluginmanager.register(plugin)
 

--- a/src/buildkite_test_collector/pytest_plugin/buildkite_plugin.py
+++ b/src/buildkite_test_collector/pytest_plugin/buildkite_plugin.py
@@ -1,6 +1,7 @@
 """Buildkite test collector plugin for Pytest"""
 import json
 import os
+from pathlib import Path
 from uuid import uuid4
 
 from filelock import FileLock
@@ -28,8 +29,9 @@ def _is_subtest_report(report):
 class BuildkitePlugin:
     """Buildkite test collector plugin for Pytest"""
 
-    def __init__(self, payload):
+    def __init__(self, payload, rootpath=None):
         self.payload = payload
+        self.rootpath = rootpath
         self.in_flight = {}
         self.spans = {}
         # Tracks nodeids whose in-flight result was set to failed by a
@@ -77,7 +79,7 @@ class BuildkitePlugin:
         chunks = report.nodeid.split("::")
         scope = "::".join(chunks[:-1])
         name = chunks[-1]
-        file_name = chunks[0]
+        file_name = self._normalize_file_path(chunks[0])
 
         test_data = TestData.start(
             uuid4(),
@@ -112,15 +114,29 @@ class BuildkitePlugin:
             logger.debug('-> started_at=%s(monotonic)', self.payload.started_at)
 
         chunks = nodeid.split("::")
+        file_name = self._normalize_file_path(location[0])
 
         test_data = TestData.start(
             uuid4(),
             scope="::".join(chunks[:-1]),
             name=chunks[-1],
-            file_name=location[0],
-            location=f"{location[0]}:{location[1]}"
+            file_name=file_name,
+            location=f"{file_name}:{location[1]}"
         )
         self.in_flight[nodeid] = test_data
+
+    def _normalize_file_path(self, path):
+        """Normalize a pytest-reported file path (relative to config.rootpath)
+        to be relative to the process's own cwd instead, mirroring what the
+        JS collectors (jest, cypress, playwright) already do. This lets
+        ta-ingestion safely rebase `file_name` when inferring
+        `test.selector.primary`, even when pytest's rootpath and the actual
+        invocation directory differ (e.g. in a monorepo).
+        """
+        if self.rootpath is None:
+            return path
+
+        return os.path.relpath(Path(self.rootpath) / path, os.getcwd())
 
     def pytest_runtest_logreport(self, report):
         """pytest_runtest_logreport hook callback to get test outcome after test call"""

--- a/tests/buildkite_test_collector/pytest_plugin/test_plugin.py
+++ b/tests/buildkite_test_collector/pytest_plugin/test_plugin.py
@@ -456,6 +456,93 @@ def test_pytest_collectreport_tuple_longrepr(fake_env):
     assert "ModuleNotFoundError" in test_data.result.failure_reason
 
 
+# ---------------------------------------------------------------------------
+# file path normalization (rootpath -> cwd)
+# ---------------------------------------------------------------------------
+
+def test_runtest_logstart_normalizes_path_in_monorepo(fake_env, tmp_path, monkeypatch):
+    """When bktec's cwd is a subdirectory of pytest's rootpath (e.g. a
+    monorepo), the uploaded file_name should be relative to that cwd, not
+    to pytest's rootpath, matching what Test Engine Client would discover
+    from the same cwd.
+    """
+    rootpath = tmp_path / "monorepo"
+    service_dir = rootpath / "services" / "foo"
+    service_dir.mkdir(parents=True)
+
+    monkeypatch.chdir(service_dir)
+
+    payload = Payload.init(fake_env)
+    plugin = BuildkitePlugin(payload, rootpath=rootpath)
+
+    # location[0] as reported by pytest is relative to rootpath
+    location = ("services/foo/test_bar.py", 10, "")
+    nodeid = "services/foo/test_bar.py::test_it"
+
+    plugin.pytest_runtest_logstart(nodeid, location)
+
+    test_data = plugin.in_flight.get(nodeid)
+    assert test_data.file_name == "test_bar.py"
+    assert test_data.location == "test_bar.py:10"
+
+
+def test_runtest_logstart_no_change_when_rootpath_is_cwd(fake_env, tmp_path, monkeypatch):
+    """The common case: rootpath == cwd. file_name should be unchanged."""
+    monkeypatch.chdir(tmp_path)
+
+    payload = Payload.init(fake_env)
+    plugin = BuildkitePlugin(payload, rootpath=tmp_path)
+
+    location = ("tests/test_bar.py", 10, "")
+    nodeid = "tests/test_bar.py::test_it"
+
+    plugin.pytest_runtest_logstart(nodeid, location)
+
+    test_data = plugin.in_flight.get(nodeid)
+    assert test_data.file_name == "tests/test_bar.py"
+    assert test_data.location == "tests/test_bar.py:10"
+
+
+def test_runtest_logstart_no_rootpath_leaves_path_untouched(fake_env):
+    """Without a rootpath (e.g. plugin constructed directly), file_name
+    falls back to the raw location, preserving prior behavior."""
+    payload = Payload.init(fake_env)
+    plugin = BuildkitePlugin(payload)
+
+    location = ("path/to/test.py", 100, "")
+    nodeid = "path/to/test.py::test_it"
+
+    plugin.pytest_runtest_logstart(nodeid, location)
+
+    test_data = plugin.in_flight.get(nodeid)
+    assert test_data.file_name == "path/to/test.py"
+
+
+def test_pytest_collectreport_normalizes_path_in_monorepo(fake_env, tmp_path, monkeypatch):
+    """Collection errors (pytest_collectreport) should also normalize
+    file_name relative to cwd, consistent with pytest_runtest_logstart."""
+    rootpath = tmp_path / "monorepo"
+    service_dir = rootpath / "services" / "foo"
+    service_dir.mkdir(parents=True)
+
+    monkeypatch.chdir(service_dir)
+
+    payload = Payload.init(fake_env)
+    plugin = BuildkitePlugin(payload, rootpath=rootpath)
+
+    report = CollectReport(
+        nodeid="services/foo/test_bar.py",
+        outcome="failed",
+        longrepr="ModuleNotFoundError: No module named 'bar'",
+        result=None,
+    )
+
+    plugin.pytest_collectreport(report)
+
+    test_data = plugin.payload.data[0]
+    assert test_data.file_name == "test_bar.py"
+
+
 def test_pytest_collectreport_deduplicates(fake_env):
     """Repeated collection errors for the same nodeid produce only one entry.
 


### PR DESCRIPTION
We wants to infer `test.selector.primary` for test results uploaded from test collectors, based on the filename that `bktec` sees. This already works for the JS collectors (jest, cypress, playwright) because they normalize their file paths to `process.cwd()` before upload.

The pytest collector didn't do this. `file_name` was set straight from pytest's own `location[0]`, which is relative to pytest's `config.rootpath`. In a monorepo, `rootpath` and the actual invocation directory (bktec's cwd) can differ, so `ta-ingestion` couldn't safely rebase the path without more info.

This mirrors what the JS collectors already do: it rebases the path onto the process's own cwd before it's uploaded, instead of leaving it rootpath-relative.

- `BuildkitePlugin` now takes an optional `rootpath`, which `pytest_configure` passes in from `config.rootpath` (a value pytest computes itself, no user config needed).
- `file_name`/`location` in both `pytest_runtest_logstart` and `pytest_collectreport` are now rebased onto `os.getcwd()` when `rootpath` is set.
- Falls back to the raw path when `rootpath` isn't provided, so behavior is unchanged for the common case where `rootpath == cwd`, and existing callers/tests aren't affected.

Added tests covering the monorepo case (cwd nested under rootpath), the `rootpath == cwd` no-op case, and the no-rootpath backward-compat case.
