### PR TITLE
Bump version to 1.5.1 [release]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "buildkite-test-collector"
-version = "1.5.0"
+version = "1.5.1"
 description = "Buildkite Test Engine collector"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cutting a release to ship everything merged since `v1.5.0`. Bumps the version `1.5.0` -> `1.5.1`, and the `[release]` tag in the title triggers the PyPI release pipeline once merged.

## PRs since v1.5.0
- #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)